### PR TITLE
Use MathJax on CDN

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -150,7 +150,7 @@ gulp.task("build", [
     "build:html",
     "build:fonts",
     "build:resources",
-    "build:mathjax",
+//    "build:mathjax",
     "build:css"
 ]);
 gulp.task("build-dev", [

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "karma-sauce-launcher": "^0.2.14",
     "karma-verbose-reporter": "0.0.3",
     "knockout": "^3.3.0",
-    "mathjax": "^2.5.1",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.3.1"
   }

--- a/src/html/vivliostyle-viewer.ejs
+++ b/src/html/vivliostyle-viewer.ejs
@@ -7,12 +7,11 @@
 <meta name="google" content="notranslate">
 <title>Vivliostyle.js viewer</title>
 <script src="resources/mathjax-config.js"></script>
+<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 <% if (development) { %>
-<script src="../node_modules/mathjax/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 <script src="../node_modules/vivliostyle/src/vivliostyle.js"></script>
 <script src="js/main-dev.js"></script>
 <% } else { %>
-<script src="mathjax/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 <script src="js/main.js"></script>
 <% } %>
 <link rel="stylesheet" href="resources/vivliostyle-viewport.css"/>


### PR DESCRIPTION
- Since the latest version (2.6.0) is not published to npm, we (temporary?) switch to the latest MathJax on CDN.