### PR TITLE
Support loading multiple HTML files

### DIFF
--- a/src/js/models/document-options.js
+++ b/src/js/models/document-options.js
@@ -22,17 +22,20 @@ import urlParameters from "../stores/url-parameters";
 import PageSize from "./page-size";
 
 function getDocumentOptionsFromURL() {
+    var epubUrl = urlParameters.getParameter("b");
+    var url = urlParameters.getParameter("x");
+    var fragment = urlParameters.getParameter("f");
     return {
-        epubUrl: urlParameters.getParameter("b"),
-        url: urlParameters.getParameter("x"),
-        fragment: urlParameters.getParameter("f")
+        epubUrl: epubUrl[0] || null,
+        url: url.length ? url : null,
+        fragment: fragment[0] || null
     };
 }
 
 function DocumentOptions() {
     var urlOptions = getDocumentOptionsFromURL();
     this.epubUrl = ko.observable(urlOptions.epubUrl || "");
-    this.url = ko.observable(urlOptions.url || "");
+    this.url = ko.observable(urlOptions.url || null);
     this.fragment = ko.observable(urlOptions.fragment || "");
     this.pageSize = new PageSize();
 

--- a/src/js/models/viewer-options.js
+++ b/src/js/models/viewer-options.js
@@ -22,8 +22,8 @@ import urlParameters from "../stores/url-parameters";
 
 function getViewerOptionsFromURL() {
     return {
-        profile: (urlParameters.getParameter("profile") === "true"),
-        spreadView: (urlParameters.getParameter("spread") === "true")
+        profile: (urlParameters.getParameter("profile")[0] === "true"),
+        spreadView: (urlParameters.getParameter("spread")[0] === "true")
     };
 }
 

--- a/src/js/stores/url-parameters.js
+++ b/src/js/stores/url-parameters.js
@@ -20,7 +20,7 @@
 import stringUtil from "../utils/string-util"
 
 function getRegExpForParameter(name) {
-    return new RegExp("[#&]" + stringUtil.escapeUnicodeString(name) + "=([^&]*)");
+    return new RegExp("[#&]" + stringUtil.escapeUnicodeString(name) + "=([^&]*)", "g");
 }
 
 function URLParameterStore() {
@@ -31,19 +31,19 @@ function URLParameterStore() {
 URLParameterStore.prototype.getParameter = function(name) {
     var url = this.location.href;
     var regexp = getRegExpForParameter(name);
-    var r = url.match(regexp);
-    if (r) {
-        return r[1];
-    } else {
-        return null;
+    var results = [];
+    var r;
+    while (r = regexp.exec(url)) {
+        results.push(r[1]);
     }
+    return results;
 };
 
 URLParameterStore.prototype.setParameter = function(name, value) {
     var url = this.location.href;
     var updated;
     var regexp = getRegExpForParameter(name);
-    var r = url.match(regexp);
+    var r = regexp.exec(url);
     if (r) {
         var l = r[1].length;
         var start = r.index + r[0].length - l;

--- a/src/js/viewmodels/viewer-app.js
+++ b/src/js/viewmodels/viewer-app.js
@@ -38,7 +38,7 @@ function ViewerApp() {
     this.viewerSettings = {
         userAgentRootURL: "resources/",
         viewportElement: document.getElementById("vivliostyle-viewer-viewport"),
-        debug: urlParameters.getParameter("debug") === "true"
+        debug: urlParameters.getParameter("debug")[0] === "true"
     };
     this.viewer = new Viewer(this.viewerSettings, this.viewerOptions);
     this.messageDialog = new MessageDialog(messageQueue);

--- a/test/spec/models/document-options-spec.js
+++ b/test/spec/models/document-options-spec.js
@@ -36,18 +36,18 @@ describe("DocumentOptions", function() {
 
     describe("constructor", function() {
         it("retrieves parameters from URL", function() {
-            urlParameters.location = {href: "http://example.com#x=abc/def.html&f=ghi"};
+            urlParameters.location = {href: "http://example.com#x=abc/def.html&f=ghi&x=jkl/mno.html"};
             var options = new DocumentOptions();
 
             expect(options.epubUrl()).toBe("");
-            expect(options.url()).toBe("abc/def.html");
+            expect(options.url()).toEqual(["abc/def.html", "jkl/mno.html"]);
             expect(options.fragment()).toBe("ghi");
 
             urlParameters.location = {href: "http://example.com#b=abc/&f=ghi"};
             options = new DocumentOptions();
 
             expect(options.epubUrl()).toBe("abc/");
-            expect(options.url()).toBe("");
+            expect(options.url()).toBe(null);
             expect(options.fragment()).toBe("ghi");
         });
     });

--- a/test/spec/stores/url-parameters-spec.js
+++ b/test/spec/stores/url-parameters-spec.js
@@ -35,18 +35,18 @@ describe("URLParameterStore", function() {
     });
 
     describe("getParameter", function() {
-        it("returns a value corresponding to the key in the URL hash", function() {
-            urlParameters.location = {href: "http://example.com#aa=bb&cc=dd"};
+        it("returns an array containing values corresponding to the key in the URL hash", function() {
+            urlParameters.location = {href: "http://example.com#aa=bb&cc=dd&cc=ee"};
 
-            expect(urlParameters.getParameter("aa")).toBe("bb");
-            expect(urlParameters.getParameter("cc")).toBe("dd");
+            expect(urlParameters.getParameter("aa")).toEqual(["bb"]);
+            expect(urlParameters.getParameter("cc")).toEqual(["dd", "ee"]);
         });
 
         it("can retrieve a value for a unicode key", function() {
             var key = "あいうえお";
             urlParameters.location = {href: "http://example.com#aa=bb&" + key + "=dd"};
 
-            expect(urlParameters.getParameter(key)).toBe("dd");
+            expect(urlParameters.getParameter(key)).toEqual(["dd"]);
         });
     });
 


### PR DESCRIPTION
If multiple ‘x’ parameters are specified in the URL hash, all these
URLs  are loaded as documents in the specified order.