### PR TITLE
Add options to disable some user operations (changing font size etc.)

### DIFF
--- a/src/html/vivliostyle-viewer.ejs
+++ b/src/html/vivliostyle-viewer.ejs
@@ -28,16 +28,16 @@
 
 <!-- MENU BAR -->
 <div id="vivliostyle-menu-bar">
-	<ul class="vivliostyle-menu" id="vivliostyle-menu_move">
+	<ul class="vivliostyle-menu" id="vivliostyle-menu_move" data-bind="visible: !navigation.hidePageNavigation">
 		<li class="vivliostyle-menu-item vivliostyle-menu-disabled" id="vivliostyle-menu-item_move-previous" data-bind="click: navigation.navigateToPrevious, css: {'vivliostyle-menu-disabled': navigation.isNavigateToPreviousDisabled}"><span class="vivliostyle-menu-icon-button" title="Move: Previous" data-bind="menuButton: true"></span></li>
 		<li class="vivliostyle-menu-item vivliostyle-menu-disabled" id="vivliostyle-menu-item_move-next" data-bind="click: navigation.navigateToNext, css: {'vivliostyle-menu-disabled': navigation.isNavigateToNextDisabled}"><span class="vivliostyle-menu-icon-button" title="Move: Next" data-bind="menuButton: true"></span></li>
 	</ul>
-	<ul class="vivliostyle-menu" id="vivliostyle-menu_zoom">
+	<ul class="vivliostyle-menu" id="vivliostyle-menu_zoom" data-bind="visible: !navigation.hideZoom">
 		<li class="vivliostyle-menu-item vivliostyle-menu-disabled" id="vivliostyle-menu-item_zoom-out" data-bind="click: navigation.zoomOut, css: {'vivliostyle-menu-disabled': navigation.isZoomOutDisabled}"><span class="vivliostyle-menu-icon-button" title="Zoom: Out" data-bind="menuButton: true"></span></li>
 		<li class="vivliostyle-menu-item vivliostyle-menu-disabled" id="vivliostyle-menu-item_zoom-in" data-bind="click: navigation.zoomIn, css: {'vivliostyle-menu-disabled': navigation.isZoomInDisabled}"><span class="vivliostyle-menu-icon-button" title="Zoom: In" data-bind="menuButton: true"></span></li>
 		<li class="vivliostyle-menu-item vivliostyle-menu-disabled" id="vivliostyle-menu-item_zoom-default" data-bind="click: navigation.zoomDefault, css: {'vivliostyle-menu-disabled': navigation.isZoomDefaultDisabled}"><span class="vivliostyle-menu-icon-button" title="Zoom: Default" data-bind="menuButton: true"></span></li>
 	</ul>
-	<ul class="vivliostyle-menu" id="vivliostyle-menu_text-size">
+	<ul class="vivliostyle-menu" id="vivliostyle-menu_text-size" data-bind="visible: !navigation.hideFontSizeChange">
 		<li class="vivliostyle-menu-item vivliostyle-menu-disabled" id="vivliostyle-menu-item_text-size-smaller" data-bind="click: navigation.decreaseFontSize, css: {'vivliostyle-menu-disabled': navigation.isDecreaseFontSizeDisabled}"><span class="vivliostyle-menu-icon-button" title="Text: Smaller" data-bind="menuButton: true"></span></li>
 		<!-- <li class="vivliostyle-menu-item vivliostyle-menu-disabled" id="vivliostyle-menu-item_text-size-default"><span class="vivliostyle-menu-icon-button" title="Text Size: Default" data-bind="menuButton: true"></span></li> -->
 		<li class="vivliostyle-menu-item vivliostyle-menu-disabled" id="vivliostyle-menu-item_text-size-larger" data-bind="click: navigation.increaseFontSize, css: {'vivliostyle-menu-disabled': navigation.isIncreaseFontSizeDisabled}"><span class="vivliostyle-menu-icon-button" title="Text: Larger" data-bind="menuButton: true"></span></li>

--- a/src/html/vivliostyle-viewer.ejs
+++ b/src/html/vivliostyle-viewer.ejs
@@ -50,9 +50,9 @@
 					<div class="vivliostyle-menu-detail-group">
 						<div class="vivliostyle-menu-detail-group-heading"><label><input type="checkbox" name="vivliostyle-misc_paginate" checked disabled /> <span>Paginate</span></label></div>
 						<div class="vivliostyle-menu-detail-group">
-							<div><label><input type="checkbox" name="vivliostyle-misc_paginate_spread-view" data-bind="checked: settingsPanel.state.viewerOptions.spreadView" /> <span>Spread View</span></label></div>
+							<div><label><input type="checkbox" name="vivliostyle-misc_paginate_spread-view" data-bind="checked: settingsPanel.state.viewerOptions.spreadView, disable: settingsPanel.isSpreadViewChangeDisabled" /> <span>Spread View</span></label></div>
 						</div>
-						<div class="vivliostyle-menu-detail-group">
+						<fieldset class="vivliostyle-menu-detail-group" data-bind="disable: settingsPanel.isPageSizeChangeDisabled">
 							<div class="vivliostyle-menu-detail-group-heading"><span>Page Size</span></div>
 							<ul class="vivliostyle-menu-detail-group">
 								<li><label><input type="radio" name="vivliostyle-misc_paginate_page-size" value="auto" required data-bind="checked: settingsPanel.state.pageSize.mode" /> <span>Auto</span> <small>(Use entire window area)</small></label></li>
@@ -71,10 +71,10 @@
 									</small>
 								</li>
 							</ul>
-						</div>
+						</fieldset>
 					</div>
 					<div class="vivliostyle-menu-detail-group">
-						<div><label><input type="checkbox" name="vivliostyle-misc_paginate_override-document-stylesheets" data-bind="checked: settingsPanel.state.pageSize.isImportant" /> <span>Override Document StyleSheets</span></label></div>
+						<div><label><input type="checkbox" name="vivliostyle-misc_paginate_override-document-stylesheets" data-bind="checked: settingsPanel.state.pageSize.isImportant, disable: settingsPanel.isOverrideDocumentStyleSheetDisabled" /> <span>Override Document StyleSheets</span></label></div>
 					</div>
 					<!--
 					<div class="vivliostyle-menu-detail-group">

--- a/src/js/viewmodels/navigation.js
+++ b/src/js/viewmodels/navigation.js
@@ -22,7 +22,7 @@ import vivliostyle from "../models/vivliostyle";
 import ViewerOptions from "../models/viewer-options";
 import {Keys} from "../utils/key-util";
 
-function Navigation(viewerOptions, viewer, settingsPanel) {
+function Navigation(viewerOptions, viewer, settingsPanel, navigationOptions) {
     this.viewerOptions_ = viewerOptions;
     this.viewer_ = viewer;
     this.settingsPanel_ = settingsPanel;
@@ -30,18 +30,36 @@ function Navigation(viewerOptions, viewer, settingsPanel) {
     this.isDisabled = ko.pureComputed(function() {
         return this.settingsPanel_.opened() || !this.viewer_.state.navigatable();
     }, this);
-    this.isNavigateToPreviousDisabled = this.isDisabled;
-    this.isNavigateToNextDisabled = this.isDisabled;
-    this.isNavigateToLeftDisabled = this.isDisabled;
-    this.isNavigateToRightDisabled = this.isDisabled;
-    this.isNavigateToFirstDisabled = this.isDisabled;
-    this.isNavigateToLastDisabled = this.isDisabled;
-    this.isZoomOutDisabled = this.isDisabled;
-    this.isZoomInDisabled = this.isDisabled;
-    this.isZoomDefaultDisabled = this.isDisabled;
-    this.isIncreaseFontSizeDisabled = this.isDisabled;
-    this.isDecreaseFontSizeDisabled = this.isDisabled;
-    this.isDefaultFontSizeDisabled = this.isDisabled;
+
+    var navigationDisabled = ko.pureComputed(function() {
+        return navigationOptions.disablePageNavigation || this.isDisabled();
+    }, this);
+
+    this.isNavigateToPreviousDisabled = navigationDisabled;
+    this.isNavigateToNextDisabled = navigationDisabled;
+    this.isNavigateToLeftDisabled = navigationDisabled;
+    this.isNavigateToRightDisabled = navigationDisabled;
+    this.isNavigateToFirstDisabled = navigationDisabled;
+    this.isNavigateToLastDisabled = navigationDisabled;
+    this.hidePageNavigation = !!navigationOptions.disablePageNavigation;
+
+    var zoomDisabled = ko.pureComputed(function() {
+        return navigationOptions.disableZoom || this.isDisabled();
+    }, this);
+
+    this.isZoomOutDisabled = zoomDisabled;
+    this.isZoomInDisabled = zoomDisabled;
+    this.isZoomDefaultDisabled = zoomDisabled;
+    this.hideZoom = !!navigationOptions.disableZoom;
+
+    var fontSizeChangeDisabled = ko.pureComputed(function() {
+        return navigationOptions.disableFontSizeChange || this.isDisabled();
+    }, this);
+
+    this.isIncreaseFontSizeDisabled = fontSizeChangeDisabled;
+    this.isDecreaseFontSizeDisabled = fontSizeChangeDisabled;
+    this.isDefaultFontSizeDisabled = fontSizeChangeDisabled;
+    this.hideFontSizeChange = !!navigationOptions.disableFontSizeChange;
 
     [
         "navigateToPrevious",

--- a/src/js/viewmodels/settings-panel.js
+++ b/src/js/viewmodels/settings-panel.js
@@ -22,10 +22,14 @@ import ViewerOptions from "../models/viewer-options";
 import PageSize from "../models/page-size";
 import {Keys} from "../utils/key-util";
 
-function SettingsPanel(viewerOptions, documentOptions, viewer, messageDialog) {
+function SettingsPanel(viewerOptions, documentOptions, viewer, messageDialog, settingsPanelOptions) {
     this.viewerOptions_ = viewerOptions;
     this.documentOptions_ = documentOptions;
     this.viewer_ = viewer;
+
+    this.isPageSizeChangeDisabled = !!settingsPanelOptions.disablePageSizeChange;
+    this.isOverrideDocumentStyleSheetDisabled = this.isPageSizeChangeDisabled;
+    this.isSpreadViewChangeDisabled = !!settingsPanelOptions.disableSpreadViewChange;
 
     this.opened = ko.observable(false);
     this.state = {

--- a/src/js/viewmodels/viewer-app.js
+++ b/src/js/viewmodels/viewer-app.js
@@ -42,7 +42,14 @@ function ViewerApp() {
     };
     this.viewer = new Viewer(this.viewerSettings, this.viewerOptions);
     this.messageDialog = new MessageDialog(messageQueue);
-    this.settingsPanel = new SettingsPanel(this.viewerOptions, this.documentOptions, this.viewer, this.messageDialog);
+
+    var settingsPanelOptions = {
+        disablePageSizeChange: false,
+        disableSpreadViewChange: true
+    };
+
+    this.settingsPanel = new SettingsPanel(this.viewerOptions, this.documentOptions, this.viewer, this.messageDialog,
+        settingsPanelOptions);
 
     var navigationOptions = {
         disablePageNavigation: false,

--- a/src/js/viewmodels/viewer-app.js
+++ b/src/js/viewmodels/viewer-app.js
@@ -43,7 +43,14 @@ function ViewerApp() {
     this.viewer = new Viewer(this.viewerSettings, this.viewerOptions);
     this.messageDialog = new MessageDialog(messageQueue);
     this.settingsPanel = new SettingsPanel(this.viewerOptions, this.documentOptions, this.viewer, this.messageDialog);
-    this.navigation = new Navigation(this.viewerOptions, this.viewer, this.settingsPanel);
+
+    var navigationOptions = {
+        disablePageNavigation: false,
+        disableZoom: false,
+        disableFontSizeChange: false
+    };
+
+    this.navigation = new Navigation(this.viewerOptions, this.viewer, this.settingsPanel, navigationOptions);
 
     this.handleKey = function(data, event) {
         var key = keyUtil.identifyKeyFromEvent(event);

--- a/src/scss/ui.menu-bar.scss
+++ b/src/scss/ui.menu-bar.scss
@@ -363,7 +363,7 @@ $animation-FLIP: FLIP 2s ease 0s infinite normal;
 						.vivliostyle-menu-detail-group {
 							padding-left: 1.3em;
 						}
-						div.vivliostyle-menu-detail-group {
+						div.vivliostyle-menu-detail-group, fieldset.vivliostyle-menu-detail-group {
 							margin-top: .8em;/*
 							padding-left: 1.2em;
 							&:before {

--- a/test/spec/viewmodels/navigation-spec.js
+++ b/test/spec/viewmodels/navigation-spec.js
@@ -24,10 +24,14 @@ import Navigation from "../../../src/js/viewmodels/navigation";
 import vivliostyleMock from "../../mock/models/vivliostyle";
 
 describe("Navigation", function() {
-    var navigation;
     var viewerOptions;
     var viewer;
     var settingsPanel;
+    var defaultNavigationOptions = {
+        disablePageNavigation: false,
+        disableZoom: false,
+        disableFontSizeChange: false
+    };
 
     vivliostyleMock();
 
@@ -44,8 +48,11 @@ describe("Navigation", function() {
             queryZoomFactor: function() {}
         };
         settingsPanel = {opened: ko.observable(false)};
-        navigation = new Navigation(viewerOptions, viewer, settingsPanel);
     });
+
+    function createNavigation(options) {
+        return new Navigation(viewerOptions, viewer, settingsPanel, options || defaultNavigationOptions);
+    }
 
     function setDisabled(val) {
         viewer.state.navigatable(!val);
@@ -53,6 +60,7 @@ describe("Navigation", function() {
 
     describe("isDisabled", function() {
         it("is true if viewer.state.navigatable is false", function() {
+            var navigation = createNavigation();
             expect(navigation.isDisabled()).toBe(true);
 
             var isDisabled = true;
@@ -65,6 +73,7 @@ describe("Navigation", function() {
         });
 
         it("is true if settingsPanel.opened is true", function() {
+            var navigation = createNavigation();
             viewer.state.navigatable(true);
 
             expect(navigation.isDisabled()).toBe(false);
@@ -81,6 +90,7 @@ describe("Navigation", function() {
         });
 
         it("calls viewer's navigateToPrevious and returns true", function() {
+            var navigation = createNavigation();
             setDisabled(false);
             var ret = navigation.navigateToPrevious();
 
@@ -89,8 +99,17 @@ describe("Navigation", function() {
         });
 
         it("do nothing and returns false when navigation is disabled", function() {
+            var navigation = createNavigation();
             setDisabled(true);
             var ret = navigation.navigateToPrevious();
+
+            expect(viewer.navigateToPrevious).not.toHaveBeenCalled();
+            expect(ret).toBe(false);
+
+            // disabled by navigationOptions
+            navigation = createNavigation({disablePageNavigation: true});
+            setDisabled(false);
+            ret = navigation.navigateToPrevious();
 
             expect(viewer.navigateToPrevious).not.toHaveBeenCalled();
             expect(ret).toBe(false);
@@ -103,6 +122,7 @@ describe("Navigation", function() {
         });
 
         it("calls viewer's navigateToNext and returns true", function() {
+            var navigation = createNavigation();
             setDisabled(false);
             var ret = navigation.navigateToNext();
 
@@ -111,8 +131,17 @@ describe("Navigation", function() {
         });
 
         it("do nothing and returns false when navigation is disabled", function() {
+            var navigation = createNavigation();
             setDisabled(true);
             var ret = navigation.navigateToNext();
+
+            expect(viewer.navigateToNext).not.toHaveBeenCalled();
+            expect(ret).toBe(false);
+
+            // disabled by navigationOptions
+            navigation = createNavigation({disablePageNavigation: true});
+            setDisabled(false);
+            ret = navigation.navigateToNext();
 
             expect(viewer.navigateToNext).not.toHaveBeenCalled();
             expect(ret).toBe(false);
@@ -125,6 +154,7 @@ describe("Navigation", function() {
         });
 
         it("calls viewer's navigateToLeft and returns true", function() {
+            var navigation = createNavigation();
             setDisabled(false);
             var ret = navigation.navigateToLeft();
 
@@ -133,8 +163,17 @@ describe("Navigation", function() {
         });
 
         it("do nothing and returns false when navigation is disabled", function() {
+            var navigation = createNavigation();
             setDisabled(true);
             var ret = navigation.navigateToLeft();
+
+            expect(viewer.navigateToLeft).not.toHaveBeenCalled();
+            expect(ret).toBe(false);
+
+            // disabled by navigationOptions
+            navigation = createNavigation({disablePageNavigation: true});
+            setDisabled(false);
+            ret = navigation.navigateToLeft();
 
             expect(viewer.navigateToLeft).not.toHaveBeenCalled();
             expect(ret).toBe(false);
@@ -147,6 +186,7 @@ describe("Navigation", function() {
         });
 
         it("calls viewer's navigateToRight and returns true", function() {
+            var navigation = createNavigation();
             setDisabled(false);
             var ret = navigation.navigateToRight();
 
@@ -155,8 +195,17 @@ describe("Navigation", function() {
         });
 
         it("do nothing and returns false when navigation is disabled", function() {
+            var navigation = createNavigation();
             setDisabled(true);
             var ret = navigation.navigateToRight();
+
+            expect(viewer.navigateToRight).not.toHaveBeenCalled();
+            expect(ret).toBe(false);
+
+            // disabled by navigationOptions
+            navigation = createNavigation({disablePageNavigation: true});
+            setDisabled(false);
+            ret = navigation.navigateToRight();
 
             expect(viewer.navigateToRight).not.toHaveBeenCalled();
             expect(ret).toBe(false);
@@ -169,6 +218,7 @@ describe("Navigation", function() {
         });
 
         it("calls viewer's navigateToFirst and returns true", function() {
+            var navigation = createNavigation();
             setDisabled(false);
             var ret = navigation.navigateToFirst();
 
@@ -177,8 +227,17 @@ describe("Navigation", function() {
         });
 
         it("do nothing and returns false when navigation is disabled", function() {
+            var navigation = createNavigation();
             setDisabled(true);
             var ret = navigation.navigateToFirst();
+
+            expect(viewer.navigateToFirst).not.toHaveBeenCalled();
+            expect(ret).toBe(false);
+
+            // disabled by navigationOptions
+            navigation = createNavigation({disablePageNavigation: true});
+            setDisabled(false);
+            ret = navigation.navigateToFirst();
 
             expect(viewer.navigateToFirst).not.toHaveBeenCalled();
             expect(ret).toBe(false);
@@ -191,6 +250,7 @@ describe("Navigation", function() {
         });
 
         it("calls viewer's navigateToLast and returns true", function() {
+            var navigation = createNavigation();
             setDisabled(false);
             var ret = navigation.navigateToLast();
 
@@ -199,16 +259,40 @@ describe("Navigation", function() {
         });
 
         it("do nothing and returns false when navigation is disabled", function() {
+            var navigation = createNavigation();
             setDisabled(true);
             var ret = navigation.navigateToLast();
+
+            expect(viewer.navigateToLast).not.toHaveBeenCalled();
+            expect(ret).toBe(false);
+
+            // disabled by navigationOptions
+            navigation = createNavigation({disablePageNavigation: true});
+            setDisabled(false);
+            ret = navigation.navigateToLast();
 
             expect(viewer.navigateToLast).not.toHaveBeenCalled();
             expect(ret).toBe(false);
         });
     });
 
+    describe("hidePageNavigation", function() {
+        it ("is false by default", function() {
+            var navigation = createNavigation();
+
+            expect(navigation.hidePageNavigation).toBe(false);
+        });
+
+        it ("is set to true by navigationOptions", function() {
+            var navigation = createNavigation({disablePageNavigation: true});
+
+            expect(navigation.hidePageNavigation).toBe(true);
+        });
+    });
+
     describe("zoomIn", function() {
         it("increases zoom factor stored in ViewerOptions model and returns true", function () {
+            var navigation = createNavigation();
             setDisabled(false);
             var zoom = viewerOptions.zoom();
             var ret = navigation.zoomIn();
@@ -223,9 +307,19 @@ describe("Navigation", function() {
         });
 
         it("do nothing and returns false when navigation is disabled", function() {
+            var navigation = createNavigation();
             setDisabled(true);
             var zoom = viewerOptions.zoom();
             var ret = navigation.zoomIn();
+
+            expect(viewerOptions.zoom()).toBe(zoom);
+            expect(ret).toBe(false);
+
+            // disabled by navigationOptions
+            navigation = createNavigation({disableZoom: true});
+            setDisabled(false);
+            zoom = viewerOptions.zoom();
+            ret = navigation.zoomIn();
 
             expect(viewerOptions.zoom()).toBe(zoom);
             expect(ret).toBe(false);
@@ -234,6 +328,7 @@ describe("Navigation", function() {
 
     describe("zoomOut", function() {
         it("decreases zoom factor stored in ViewerOptions model and returns true", function() {
+            var navigation = createNavigation();
             setDisabled(false);
             var zoom = viewerOptions.zoom();
             var ret = navigation.zoomOut();
@@ -248,9 +343,19 @@ describe("Navigation", function() {
         });
 
         it("do nothing and returns false when navigation is disabled", function() {
+            var navigation = createNavigation();
             setDisabled(true);
             var zoom = viewerOptions.zoom();
             var ret = navigation.zoomOut();
+
+            expect(viewerOptions.zoom()).toBe(zoom);
+            expect(ret).toBe(false);
+
+            // disabled by navigationOptions
+            navigation = createNavigation({disableZoom: true});
+            setDisabled(false);
+            zoom = viewerOptions.zoom();
+            ret = navigation.zoomOut();
 
             expect(viewerOptions.zoom()).toBe(zoom);
             expect(ret).toBe(false);
@@ -263,6 +368,7 @@ describe("Navigation", function() {
         });
 
         it("query zoom factor for 'fit inside viewport' to the viewer and set returned zoom factor in ViewerOptions model and returns true", function() {
+            var navigation = createNavigation();
             setDisabled(false);
             viewerOptions.zoom(1);
             var ret = navigation.zoomDefault();
@@ -273,6 +379,7 @@ describe("Navigation", function() {
         });
 
         it("do nothing and returns false when navigation is disabled", function() {
+            var navigation = createNavigation();
             setDisabled(true);
             viewerOptions.zoom(1);
             var ret = navigation.zoomDefault();
@@ -280,9 +387,19 @@ describe("Navigation", function() {
             expect(viewer.queryZoomFactor).not.toHaveBeenCalled();
             expect(viewerOptions.zoom()).toBe(1);
             expect(ret).toBe(false);
+
+            // disabled by navigationOptions
+            navigation = createNavigation({disableZoom: true});
+            setDisabled(false);
+            ret = navigation.zoomDefault();
+
+            expect(viewer.queryZoomFactor).not.toHaveBeenCalled();
+            expect(viewerOptions.zoom()).toBe(1);
+            expect(ret).toBe(false);
         });
 
         it("if force=true is specified, do the zoom even if navigation is disabled", function() {
+            var navigation = createNavigation();
             setDisabled(true);
             viewerOptions.zoom(1);
 
@@ -301,8 +418,23 @@ describe("Navigation", function() {
         });
     });
 
+    describe("hideZoom", function() {
+        it ("is false by default", function() {
+            var navigation = createNavigation();
+
+            expect(navigation.hideZoom).toBe(false);
+        });
+
+        it ("is set to true by navigationOptions", function() {
+            var navigation = createNavigation({disableZoom: true});
+
+            expect(navigation.hideZoom).toBe(true);
+        });
+    });
+
     describe("increaseFontSize", function() {
         it("increases font size stored in ViewerOptions model and returns true", function () {
+            var navigation = createNavigation();
             setDisabled(false);
             var fontSize = viewerOptions.fontSize();
             var ret = navigation.increaseFontSize();
@@ -317,9 +449,18 @@ describe("Navigation", function() {
         });
 
         it("do nothing and returns false when navigation is disabled", function() {
+            var navigation = createNavigation();
             setDisabled(true);
             var fontSize = viewerOptions.fontSize();
             var ret = navigation.increaseFontSize();
+
+            expect(viewerOptions.fontSize()).toBe(fontSize);
+            expect(ret).toBe(false);
+
+            // disabled by navigationOptions
+            navigation = createNavigation({disableFontSizeChange: true});
+            setDisabled(false);
+            ret = navigation.increaseFontSize();
 
             expect(viewerOptions.fontSize()).toBe(fontSize);
             expect(ret).toBe(false);
@@ -328,6 +469,7 @@ describe("Navigation", function() {
 
     describe("decreaseFontSize", function() {
         it("decreases font size stored in ViewerOptions model and returns true", function() {
+            var navigation = createNavigation();
             setDisabled(false);
             var fontSize = viewerOptions.fontSize();
             var ret = navigation.decreaseFontSize();
@@ -342,9 +484,18 @@ describe("Navigation", function() {
         });
 
         it("do nothing and returns false when navigation is disabled", function() {
+            var navigation = createNavigation();
             setDisabled(true);
             var fontSize = viewerOptions.fontSize();
             var ret = navigation.decreaseFontSize();
+
+            expect(viewerOptions.fontSize()).toBe(fontSize);
+            expect(ret).toBe(false);
+
+            // disabled by navigationOptions
+            navigation = createNavigation({disableFontSizeChange: true});
+            setDisabled(false);
+            ret = navigation.decreaseFontSize();
 
             expect(viewerOptions.fontSize()).toBe(fontSize);
             expect(ret).toBe(false);
@@ -353,6 +504,7 @@ describe("Navigation", function() {
 
     describe("defaultFontSize", function() {
         it("set font size stored in ViewerOptions model to default and returns true", function() {
+            var navigation = createNavigation();
             setDisabled(false);
             var fontSize = ViewerOptions.getDefaultValues().fontSize;
             viewerOptions.fontSize(20);
@@ -369,6 +521,7 @@ describe("Navigation", function() {
         });
 
         it("do nothing and returns false when navigation is disabled", function() {
+            var navigation = createNavigation();
             setDisabled(true);
             var fontSize = 20;
             viewerOptions.fontSize(20);
@@ -376,6 +529,28 @@ describe("Navigation", function() {
 
             expect(viewerOptions.fontSize()).toBe(fontSize);
             expect(ret).toBe(false);
+
+            // disabled by navigationOptions
+            navigation = createNavigation({disableFontSizeChange: true});
+            setDisabled(false);
+            ret = navigation.defaultFontSize();
+
+            expect(viewerOptions.fontSize()).toBe(fontSize);
+            expect(ret).toBe(false);
+        });
+    });
+
+    describe("hideFontSizeChange", function() {
+        it ("is false by default", function() {
+            var navigation = createNavigation();
+
+            expect(navigation.hideFontSizeChange).toBe(false);
+        });
+
+        it ("is set to true by navigationOptions", function() {
+            var navigation = createNavigation({disableFontSizeChange: true});
+
+            expect(navigation.hideFontSizeChange).toBe(true);
         });
     });
 });

--- a/test/spec/viewmodels/settings-panel-spec.js
+++ b/test/spec/viewmodels/settings-panel-spec.js
@@ -27,8 +27,12 @@ describe("SettingsPanel", function() {
     var documentOptions;
     var viewerOptions;
     var viewer;
-    var settingsPanel;
     var messageDialog;
+
+    var defaultSettingsPanelOptions = {
+        disablePageSizeChange: false,
+        disableSpreadViewChange: false
+    };
 
     beforeEach(function() {
         documentOptions = new DocumentOptions();
@@ -38,12 +42,17 @@ describe("SettingsPanel", function() {
         viewerOptions.fontSize(10);
         viewer = {loadDocument: function() {}};
         messageDialog = {visible: ko.observable(false)};
-
-        settingsPanel = new SettingsPanel(viewerOptions, documentOptions, viewer, messageDialog);
     });
+
+    function createSettingsPanel(options) {
+        return new SettingsPanel(viewerOptions, documentOptions, viewer, messageDialog,
+            options || defaultSettingsPanelOptions);
+    }
 
     describe("constructor", function() {
         it("stores the options to 'state' property", function() {
+            var settingsPanel = createSettingsPanel();
+
             expect(settingsPanel.state.viewerOptions.spreadView()).toBe(true);
             expect(settingsPanel.state.viewerOptions.fontSize()).toBe(10);
             expect(settingsPanel.state.pageSize.customWidth()).toBe("100mm");
@@ -52,6 +61,8 @@ describe("SettingsPanel", function() {
 
     describe("toggle", function() {
         it("toggles 'opened' property", function() {
+            var settingsPanel = createSettingsPanel();
+
             expect(settingsPanel.opened()).toBe(false);
 
             settingsPanel.toggle();
@@ -65,7 +76,9 @@ describe("SettingsPanel", function() {
     });
 
     it("closes when the error dialog is visible", function() {
+        var settingsPanel = createSettingsPanel();
         settingsPanel.toggle();
+
         expect(settingsPanel.opened()).toBe(true);
 
         messageDialog.visible(true);
@@ -75,6 +88,7 @@ describe("SettingsPanel", function() {
 
     describe("apply", function() {
         it("writes parameters from this.state.viewerOptions to the original ViewerOptions if the page size is not changed", function() {
+            var settingsPanel = createSettingsPanel();
             settingsPanel.state.viewerOptions.spreadView(false);
             settingsPanel.state.viewerOptions.fontSize(20);
 
@@ -88,6 +102,7 @@ describe("SettingsPanel", function() {
         });
 
         it("writes parameters from this.state.pageSize to the original DocumentOptions and call viewer.loadDocument if the page size is changed", function() {
+            var settingsPanel = createSettingsPanel();
             settingsPanel.state.viewerOptions.spreadView(false);
             settingsPanel.state.viewerOptions.fontSize(20);
             settingsPanel.state.pageSize.mode(PageSize.Mode.PRESET);
@@ -101,11 +116,12 @@ describe("SettingsPanel", function() {
             expect(viewerOptions.fontSize()).toBe(10);
             expect(documentOptions.pageSize.mode()).toBe(PageSize.Mode.PRESET);
             expect(viewer.loadDocument).toHaveBeenCalledWith(documentOptions, settingsPanel.state.viewerOptions);
-        })
+        });
     });
 
     describe("reset", function() {
         it("writes parameters from the original ViewerOptions to this.state.viewerOptions", function() {
+            var settingsPanel = createSettingsPanel();
             settingsPanel.state.viewerOptions.spreadView(false);
             settingsPanel.state.viewerOptions.fontSize(20);
             settingsPanel.state.pageSize.mode(PageSize.Mode.PRESET);
@@ -115,6 +131,32 @@ describe("SettingsPanel", function() {
             expect(settingsPanel.state.viewerOptions.spreadView()).toBe(true);
             expect(settingsPanel.state.viewerOptions.fontSize()).toBe(10);
             expect(settingsPanel.state.pageSize.mode()).toBe(PageSize.Mode.AUTO);
+        });
+    });
+
+    describe("UI disabled flags", function() {
+        it("all flags are false by default", function() {
+            var settingsPanel = createSettingsPanel();
+
+            expect(settingsPanel.isPageSizeChangeDisabled).toBe(false);
+            expect(settingsPanel.isOverrideDocumentStyleSheetDisabled).toBe(false);
+            expect(settingsPanel.isSpreadViewChangeDisabled).toBe(false);
+        });
+
+        it("page size change and 'override document style sheet' are disabled by disablePageSizeChange=true in settingsPanelOptions", function() {
+            var settingsPanel = createSettingsPanel({disablePageSizeChange: true});
+
+            expect(settingsPanel.isPageSizeChangeDisabled).toBe(true);
+            expect(settingsPanel.isOverrideDocumentStyleSheetDisabled).toBe(true);
+            expect(settingsPanel.isSpreadViewChangeDisabled).toBe(false);
+        });
+
+        it("spread view change is disabled by disableSpreadViewChangeChange=true in settingsPanelOptions", function() {
+            var settingsPanel = createSettingsPanel({disableSpreadViewChange: true});
+
+            expect(settingsPanel.isPageSizeChangeDisabled).toBe(false);
+            expect(settingsPanel.isOverrideDocumentStyleSheetDisabled).toBe(false);
+            expect(settingsPanel.isSpreadViewChangeDisabled).toBe(true);
         });
     });
 });


### PR DESCRIPTION
- Page navigation, zoom in/out and increasing/decreasing font size can be disabled separately by `navigationOptions` argument to `Navigation` viewmodel.
  - When disabled, corresponding buttons on the navigation bar are hidden.
- Changing page size and spread view can be disabled separately by `settingsPanelOptions` argument to `SettingsPanel` viewmodel.
  - When page size control is disabled, "Override Document StyleSheets" checkbox is also disabled.
- There is currently no way to specify these options without modifying JS code.