### PR TITLE
Load external user stylesheets specified in URL parameter

### DIFF
--- a/src/js/models/document-options.js
+++ b/src/js/models/document-options.js
@@ -25,10 +25,12 @@ function getDocumentOptionsFromURL() {
     var epubUrl = urlParameters.getParameter("b");
     var url = urlParameters.getParameter("x");
     var fragment = urlParameters.getParameter("f");
+    var style = urlParameters.getParameter("style");
     return {
         epubUrl: epubUrl[0] || null,
         url: url.length ? url : null,
-        fragment: fragment[0] || null
+        fragment: fragment[0] || null,
+        userStyleSheet: style.length ? style : []
     };
 }
 
@@ -37,6 +39,7 @@ function DocumentOptions() {
     this.epubUrl = ko.observable(urlOptions.epubUrl || "");
     this.url = ko.observable(urlOptions.url || null);
     this.fragment = ko.observable(urlOptions.fragment || "");
+    this.userStyleSheet = ko.observable(urlOptions.userStyleSheet);
     this.pageSize = new PageSize();
 
     // write fragment back to URL when updated
@@ -47,13 +50,14 @@ function DocumentOptions() {
 }
 
 DocumentOptions.prototype.toObject = function() {
+    var uss = this.userStyleSheet().map(function(url) { return {url: url}; });
     // Do not include url
     // (url is a required argument to Viewer.loadDocument, separated from other options)
     return {
         fragment: this.fragment(),
-        userStyleSheet: [{
+        userStyleSheet: uss.concat([{
             text: "@page {" + this.pageSize.toCSSDeclarationString() + "}"
-        }]
+        }])
     };
 };
 

--- a/test/spec/models/document-options-spec.js
+++ b/test/spec/models/document-options-spec.js
@@ -42,13 +42,15 @@ describe("DocumentOptions", function() {
             expect(options.epubUrl()).toBe("");
             expect(options.url()).toEqual(["abc/def.html", "jkl/mno.html"]);
             expect(options.fragment()).toBe("ghi");
+            expect(options.userStyleSheet()).toEqual([]);
 
-            urlParameters.location = {href: "http://example.com#b=abc/&f=ghi"};
+            urlParameters.location = {href: "http://example.com#b=abc/&f=ghi&style=style1&style=style2"};
             options = new DocumentOptions();
 
             expect(options.epubUrl()).toBe("abc/");
             expect(options.url()).toBe(null);
             expect(options.fragment()).toBe("ghi");
+            expect(options.userStyleSheet()).toEqual(["style1", "style2"]);
         });
     });
 
@@ -65,12 +67,14 @@ describe("DocumentOptions", function() {
             var options = new DocumentOptions();
             options.url("abc/def.html");
             options.fragment("ghi");
+            options.userStyleSheet(["style1", "style2"]);
 
             expect(options.toObject()).toEqual({
                 fragment: "ghi",
-                userStyleSheet: [{
-                    text: "@page {size: auto;}"
-                }]
+                userStyleSheet: [
+                    { url: "style1" },
+                    { url: "style2" },
+                    { text: "@page {size: auto;}" }]
             });
         });
     });


### PR DESCRIPTION
- 'style' URL parameter can be used to load external stylesheets as user stylesheets. The parameter can be specified multiple times. In that case, the specified stylesheets are loaded in the specified order.