### PR TITLE
Support adding author style sheets via 'style' URL parameter

### DIFF
--- a/src/js/models/document-options.js
+++ b/src/js/models/document-options.js
@@ -26,11 +26,13 @@ function getDocumentOptionsFromURL() {
     var url = urlParameters.getParameter("x");
     var fragment = urlParameters.getParameter("f");
     var style = urlParameters.getParameter("style");
+    var userStyle = urlParameters.getParameter("userStyle");
     return {
         epubUrl: epubUrl[0] || null,
         url: url.length ? url : null,
         fragment: fragment[0] || null,
-        userStyleSheet: style.length ? style : []
+        authorStyleSheet: style.length ? style : [],
+        userStyleSheet: userStyle.length ? userStyle : []
     };
 }
 
@@ -39,6 +41,7 @@ function DocumentOptions() {
     this.epubUrl = ko.observable(urlOptions.epubUrl || "");
     this.url = ko.observable(urlOptions.url || null);
     this.fragment = ko.observable(urlOptions.fragment || "");
+    this.authorStyleSheet = ko.observable(urlOptions.authorStyleSheet);
     this.userStyleSheet = ko.observable(urlOptions.userStyleSheet);
     this.pageSize = new PageSize();
 
@@ -50,11 +53,15 @@ function DocumentOptions() {
 }
 
 DocumentOptions.prototype.toObject = function() {
-    var uss = this.userStyleSheet().map(function(url) { return {url: url}; });
+    function convertStyleSheetArray(arr) {
+        return arr.map(function(url) { return {url: url}; });
+    }
+    var uss = convertStyleSheetArray(this.userStyleSheet());
     // Do not include url
     // (url is a required argument to Viewer.loadDocument, separated from other options)
     return {
         fragment: this.fragment(),
+        authorStyleSheet: convertStyleSheetArray(this.authorStyleSheet()),
         userStyleSheet: [{
             text: "@page {" + this.pageSize.toCSSDeclarationString() + "}"
         }].concat(uss)

--- a/src/js/models/document-options.js
+++ b/src/js/models/document-options.js
@@ -55,9 +55,9 @@ DocumentOptions.prototype.toObject = function() {
     // (url is a required argument to Viewer.loadDocument, separated from other options)
     return {
         fragment: this.fragment(),
-        userStyleSheet: uss.concat([{
+        userStyleSheet: [{
             text: "@page {" + this.pageSize.toCSSDeclarationString() + "}"
-        }])
+        }].concat(uss)
     };
 };
 

--- a/test/spec/models/document-options-spec.js
+++ b/test/spec/models/document-options-spec.js
@@ -44,13 +44,14 @@ describe("DocumentOptions", function() {
             expect(options.fragment()).toBe("ghi");
             expect(options.userStyleSheet()).toEqual([]);
 
-            urlParameters.location = {href: "http://example.com#b=abc/&f=ghi&style=style1&style=style2"};
+            urlParameters.location = {href: "http://example.com#b=abc/&f=ghi&style=style1&style=style2&userStyle=style3"};
             options = new DocumentOptions();
 
             expect(options.epubUrl()).toBe("abc/");
             expect(options.url()).toBe(null);
             expect(options.fragment()).toBe("ghi");
-            expect(options.userStyleSheet()).toEqual(["style1", "style2"]);
+            expect(options.authorStyleSheet()).toEqual(["style1", "style2"]);
+            expect(options.userStyleSheet()).toEqual(["style3"]);
         });
     });
 
@@ -67,14 +68,18 @@ describe("DocumentOptions", function() {
             var options = new DocumentOptions();
             options.url("abc/def.html");
             options.fragment("ghi");
-            options.userStyleSheet(["style1", "style2"]);
+            options.authorStyleSheet(["style1", "style2"]);
+            options.userStyleSheet(["style3"]);
 
             expect(options.toObject()).toEqual({
                 fragment: "ghi",
-                userStyleSheet: [
-                    { text: "@page {size: auto;}" },
+                authorStyleSheet: [
                     { url: "style1" },
                     { url: "style2" }
+                ],
+                userStyleSheet: [
+                    { text: "@page {size: auto;}" },
+                    { url: "style3" }
                 ]
             });
         });

--- a/test/spec/models/document-options-spec.js
+++ b/test/spec/models/document-options-spec.js
@@ -72,9 +72,10 @@ describe("DocumentOptions", function() {
             expect(options.toObject()).toEqual({
                 fragment: "ghi",
                 userStyleSheet: [
+                    { text: "@page {size: auto;}" },
                     { url: "style1" },
-                    { url: "style2" },
-                    { text: "@page {size: auto;}" }]
+                    { url: "style2" }
+                ]
             });
         });
     });


### PR DESCRIPTION
- Style sheets specified by `style` URL parameter are now treated as author style sheets.
- User style sheets can still be added by `userStyle` URL parameter.
- A bug that the page size specified on UI is treated as if it is specified after user style sheets (which makes it difficult to override the page size with the user style sheets) is also fixed.