### PR TITLE
Change 'Spread View' option to 'Page View Mode' option

### DIFF
--- a/src/html/vivliostyle-viewer.ejs
+++ b/src/html/vivliostyle-viewer.ejs
@@ -23,7 +23,7 @@
 <style id="vivliostyle-page-rules"></style>
 </head>
 <body data-vivliostyle-viewer-status="loading" data-bind="event: {keydown: handleKey}, attr: {'data-vivliostyle-viewer-status': viewer.state.status}">
-<div id="vivliostyle-viewer-viewport" data-vivliostyle-viewer-viewport="true" data-bind="attr: {'data-vivliostyle-page-progression': viewer.state.pageProgression, 'data-vivliostyle-spread-view': viewerOptions.spreadView}, click: settingsPanel.close"></div>
+<div id="vivliostyle-viewer-viewport" data-vivliostyle-viewer-viewport="true" data-bind="attr: {'data-vivliostyle-page-progression': viewer.state.pageProgression}, click: settingsPanel.close"></div>
 <span id="vivliostyle-page-navigation-left" title="navigate to left" data-bind="click: navigation.navigateToLeft, css: {'vivliostyle-menu-enabled': !navigation.isNavigateToLeftDisabled()}"></span>
 <span id="vivliostyle-page-navigation-right" title="navigate to right" data-bind="click: navigation.navigateToRight, css: {'vivliostyle-menu-enabled': !navigation.isNavigateToRightDisabled()}"></span>
 <div id="vivliostyle-loading-overlay" data-bind="visible: !isDebug">
@@ -54,9 +54,14 @@
 				<div class="vivliostyle-menu-detail-main">
 					<div class="vivliostyle-menu-detail-group">
 						<div class="vivliostyle-menu-detail-group-heading"><label><input type="checkbox" name="vivliostyle-misc_paginate" checked disabled /> <span>Paginate</span></label></div>
-						<div class="vivliostyle-menu-detail-group" data-bind="visible: !settingsPanel.isSpreadViewChangeDisabled">
-							<div><label><input type="checkbox" name="vivliostyle-misc_paginate_spread-view" data-bind="checked: settingsPanel.state.viewerOptions.spreadView, disable: settingsPanel.isSpreadViewChangeDisabled" /> <span>Spread View</span></label></div>
-						</div>
+						<fieldset class="vivliostyle-menu-detail-group" data-bind="disable: settingsPanel.isPageViewModeChangeDisabled, visible: !settingsPanel.isPageViewModeChangeDisabled">
+							<div class="vivliostyle-menu-detail-group-heading"><span>Page View Mode</span></div>
+							<ul class="vivliostyle-menu-detail-group">
+								<li><label><input type="radio" name="vivliostyle-misc_paginate_page-view-mode" value="autoSpread" required data-bind="checked: settingsPanel.state.pageViewMode" /> <span>Auto</span></label></li>
+								<li><label><input type="radio" name="vivliostyle-misc_paginate_page-view-mode" value="singlePage" required data-bind="checked: settingsPanel.state.pageViewMode" /> <span>Single page</span></label></li>
+								<li><label><input type="radio" name="vivliostyle-misc_paginate_page-view-mode" value="spread" required data-bind="checked: settingsPanel.state.pageViewMode" /> <span>Spread</span></label></li>
+							</ul>
+						</fieldset>
 						<fieldset class="vivliostyle-menu-detail-group" data-bind="disable: settingsPanel.isPageSizeChangeDisabled, visible: !settingsPanel.isPageSizeChangeDisabled">
 							<div class="vivliostyle-menu-detail-group-heading"><span>Page Size</span></div>
 							<ul class="vivliostyle-menu-detail-group">

--- a/src/js/models/page-view-mode.js
+++ b/src/js/models/page-view-mode.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 Vivliostyle Inc.
+ *
+ * This file is part of Vivliostyle UI.
+ *
+ * Vivliostyle UI is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vivliostyle UI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Vivliostyle UI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import vivliostyle from "../models/vivliostyle";
+
+class PageViewModeInstance {
+    toSpreadViewString() {
+        switch (this) {
+            case PageViewMode.SPREAD:
+                return "true";
+            case PageViewMode.SINGLE_PAGE:
+                return "false";
+            case PageViewMode.AUTO_SPREAD:
+                return "auto";
+            default:
+                throw new Error("Invalid PageViewMode");
+        }
+    }
+    toString() {
+        switch (this) {
+            case PageViewMode.SPREAD:
+                return vivliostyle.viewer.PageViewMode.SPREAD;
+            case PageViewMode.SINGLE_PAGE:
+                return vivliostyle.viewer.PageViewMode.SINGLE_PAGE;
+            case PageViewMode.AUTO_SPREAD:
+                return vivliostyle.viewer.PageViewMode.AUTO_SPREAD;
+            default:
+                throw new Error("Invalid PageViewMode");
+        }
+    }
+}
+
+const PageViewMode = {
+    AUTO_SPREAD: new PageViewModeInstance(),
+    SINGLE_PAGE: new PageViewModeInstance(),
+    SPREAD: new PageViewModeInstance(),
+    defaultMode() {
+        return this.AUTO_SPREAD;
+    },
+    fromSpreadViewString(str) {
+        switch (str) {
+            case "true":
+                return this.SPREAD;
+            case "false":
+                return this.SINGLE_PAGE;
+            case "auto":
+            default:
+                return this.AUTO_SPREAD;
+        }
+    },
+    of(name) {
+        switch (name) {
+            case vivliostyle.viewer.PageViewMode.SPREAD:
+                return this.SPREAD;
+            case vivliostyle.viewer.PageViewMode.SINGLE_PAGE:
+                return this.SINGLE_PAGE;
+            case vivliostyle.viewer.PageViewMode.AUTO_SPREAD:
+                return this.AUTO_SPREAD;
+            default:
+                throw new Error("Invalid PageViewMode name: " + name)
+        }
+    }
+};
+
+export default PageViewMode;

--- a/src/js/models/viewer-options.js
+++ b/src/js/models/viewer-options.js
@@ -19,12 +19,13 @@
 
 import ko from "knockout";
 import urlParameters from "../stores/url-parameters";
+import PageViewMode from "./page-view-mode";
 import ZoomOptions from "./zoom-options";
 
 function getViewerOptionsFromURL() {
     return {
         profile: (urlParameters.getParameter("profile")[0] === "true"),
-        spreadView: (urlParameters.getParameter("spread")[0] === "true")
+        pageViewMode: PageViewMode.fromSpreadViewString(urlParameters.getParameter("spread")[0])
     };
 }
 
@@ -32,7 +33,7 @@ function getDefaultValues() {
     return {
         fontSize: 16,
         profile: false,
-        spreadView: false,
+        pageViewMode: PageViewMode.defaultMode(),
         zoom: ZoomOptions.createDefaultOptions()
     };
 }
@@ -40,7 +41,7 @@ function getDefaultValues() {
 function ViewerOptions(options) {
     this.fontSize = ko.observable();
     this.profile = ko.observable();
-    this.spreadView = ko.observable();
+    this.pageViewMode = ko.observable();
     this.zoom = ko.observable();
     if (options) {
         this.copyFrom(options);
@@ -49,12 +50,12 @@ function ViewerOptions(options) {
         var urlOptions = getViewerOptionsFromURL();
         this.fontSize(defaultValues.fontSize);
         this.profile(urlOptions.profile || defaultValues.profile);
-        this.spreadView(urlOptions.spreadView || defaultValues.spreadView);
+        this.pageViewMode(urlOptions.pageViewMode || defaultValues.pageViewMode);
         this.zoom(defaultValues.zoom);
 
         // write spread parameter back to URL when updated
-        this.spreadView.subscribe(function(spread) {
-            urlParameters.setParameter("spread", spread);
+        this.pageViewMode.subscribe(function(pageViewMode) {
+            urlParameters.setParameter("spread", pageViewMode.toSpreadViewString());
         });
     }
 }
@@ -62,14 +63,14 @@ function ViewerOptions(options) {
 ViewerOptions.prototype.copyFrom = function(other) {
     this.fontSize(other.fontSize());
     this.profile(other.profile());
-    this.spreadView(other.spreadView());
+    this.pageViewMode(other.pageViewMode());
     this.zoom(other.zoom());
 };
 
 ViewerOptions.prototype.toObject = function() {
     return {
         fontSize: this.fontSize(),
-        spreadView: this.spreadView(),
+        pageViewMode: this.pageViewMode().toString(),
         zoom: this.zoom().zoom,
         fitToScreen: this.zoom().fitToScreen
     }

--- a/src/js/viewmodels/settings-panel.js
+++ b/src/js/viewmodels/settings-panel.js
@@ -20,6 +20,7 @@
 import ko from "knockout";
 import ViewerOptions from "../models/viewer-options";
 import PageSize from "../models/page-size";
+import PageViewMode from "../models/page-view-mode";
 import {Keys} from "../utils/key-util";
 
 function SettingsPanel(viewerOptions, documentOptions, viewer, messageDialog, settingsPanelOptions) {
@@ -29,12 +30,20 @@ function SettingsPanel(viewerOptions, documentOptions, viewer, messageDialog, se
 
     this.isPageSizeChangeDisabled = !!settingsPanelOptions.disablePageSizeChange;
     this.isOverrideDocumentStyleSheetDisabled = this.isPageSizeChangeDisabled;
-    this.isSpreadViewChangeDisabled = !!settingsPanelOptions.disableSpreadViewChange;
+    this.isPageViewModeChangeDisabled = !!settingsPanelOptions.disablePageViewModeChange;
 
     this.opened = ko.observable(false);
     this.state = {
         viewerOptions: new ViewerOptions(viewerOptions),
-        pageSize: new PageSize(documentOptions.pageSize)
+        pageSize: new PageSize(documentOptions.pageSize),
+        pageViewMode: ko.pureComputed({
+            read: () => {
+                return this.state.viewerOptions.pageViewMode().toString();
+            },
+            write: value => {
+                this.state.viewerOptions.pageViewMode(PageViewMode.of(value));
+            }
+        })
     };
 
     ["close", "toggle", "apply", "reset"].forEach(function(methodName) {

--- a/src/js/viewmodels/viewer-app.js
+++ b/src/js/viewmodels/viewer-app.js
@@ -47,7 +47,7 @@ function ViewerApp() {
 
     var settingsPanelOptions = {
         disablePageSizeChange: false,
-        disableSpreadViewChange: false
+        disablePageViewModeChange: false
     };
 
     this.settingsPanel = new SettingsPanel(this.viewerOptions, this.documentOptions, this.viewer, this.messageDialog,

--- a/test/mock/models/vivliostyle.js
+++ b/test/mock/models/vivliostyle.js
@@ -23,6 +23,11 @@ export default function() {
     beforeAll(function() {
         vivliostyle.setInstance({
             viewer: {
+                PageViewMode: {
+                    SINGLE_PAGE: "singlePage",
+                    SPREAD: "spread",
+                    AUTO_SPREAD: "autoSpread"
+                },
                 ZoomType: {
                     FIT_INSIDE_VIEWPORT: "fit inside viewport"
                 }

--- a/test/spec/models/viewer-options-spec.js
+++ b/test/spec/models/viewer-options-spec.js
@@ -17,12 +17,17 @@
  * along with Vivliostyle UI.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import vivliostyle from "../../../src/js/models/vivliostyle";
+import PageViewMode from "../../../src/js/models/page-view-mode";
 import ViewerOptions from "../../../src/js/models/viewer-options";
 import ZoomOptions from "../../../src/js/models/zoom-options";
 import urlParameters from "../../../src/js/stores/url-parameters";
+import vivliostyleMock from "../../mock/models/vivliostyle";
 
 describe("ViewerOptions", function() {
     var history, location;
+
+    vivliostyleMock();
 
     beforeEach(function() {
         history = urlParameters.history;
@@ -40,22 +45,27 @@ describe("ViewerOptions", function() {
             urlParameters.location = {href: "http://example.com#spread=true"};
             var options = new ViewerOptions();
 
-            expect(options.spreadView()).toBe(true);
+            expect(options.pageViewMode()).toEqual(PageViewMode.SPREAD);
 
             urlParameters.location = {href: "http://example.com#spread=false"};
             options = new ViewerOptions();
 
-            expect(options.spreadView()).toBe(false);
+            expect(options.pageViewMode()).toBe(PageViewMode.SINGLE_PAGE);
+
+            urlParameters.location = {href: "http://example.com#spread=auto"};
+            options = new ViewerOptions();
+
+            expect(options.pageViewMode()).toBe(PageViewMode.AUTO_SPREAD);
         });
 
         it("copies parameters from the argument", function() {
             var other = new ViewerOptions();
-            other.spreadView(false);
+            other.pageViewMode(PageViewMode.SINGLE_PAGE);
             other.fontSize(20);
             other.zoom(ZoomOptions.createFromZoomFactor(1.2));
             var options = new ViewerOptions(other);
 
-            expect(options.spreadView()).toBe(false);
+            expect(options.pageViewMode()).toBe(PageViewMode.SINGLE_PAGE);
             expect(options.fontSize()).toBe(20);
             expect(options.zoom().zoom).toBe(1.2);
             expect(options.zoom().fitToScreen).toBe(false);
@@ -65,21 +75,25 @@ describe("ViewerOptions", function() {
     it("write spread option back to URL when update if it is constructed with no argument", function() {
         urlParameters.location = {href: "http://example.com#spread=true"};
         var options = new ViewerOptions();
-        options.spreadView(false);
+        options.pageViewMode(PageViewMode.SINGLE_PAGE);
 
         expect(urlParameters.location.href).toBe("http://example.com#spread=false");
 
-        options.spreadView(true);
+        options.pageViewMode(PageViewMode.SPREAD);
 
         expect(urlParameters.location.href).toBe("http://example.com#spread=true");
 
+        options.pageViewMode(PageViewMode.AUTO_SPREAD);
+
+        expect(urlParameters.location.href).toBe("http://example.com#spread=auto");
+
         // not write back if it is constructed with another ViewerOptions
         var other = new ViewerOptions();
-        other.spreadView(false);
+        other.pageViewMode(PageViewMode.SINGLE_PAGE);
         other.fontSize(20);
         other.zoom(ZoomOptions.createFromZoomFactor(1.2));
         options = new ViewerOptions(other);
-        options.spreadView(true);
+        options.pageViewMode(PageViewMode.SPREAD);
 
         expect(urlParameters.location.href).toBe("http://example.com#spread=false");
     });
@@ -87,16 +101,16 @@ describe("ViewerOptions", function() {
     describe("copyFrom", function() {
         it("copies parameters from the argument to itself", function() {
             var options = new ViewerOptions();
-            options.spreadView(true);
+            options.pageViewMode(PageViewMode.SPREAD);
             options.fontSize(10);
             options.zoom(ZoomOptions.createFromZoomFactor(1.4));
             var other = new ViewerOptions();
-            other.spreadView(false);
+            other.pageViewMode(PageViewMode.SINGLE_PAGE);
             other.fontSize(20);
             other.zoom(ZoomOptions.createFromZoomFactor(1.2));
             options.copyFrom(other);
 
-            expect(options.spreadView()).toBe(false);
+            expect(options.pageViewMode()).toBe(PageViewMode.SINGLE_PAGE);
             expect(options.fontSize()).toBe(20);
             expect(options.zoom().zoom).toBe(1.2);
             expect(options.zoom().fitToScreen).toBe(false);
@@ -106,13 +120,13 @@ describe("ViewerOptions", function() {
     describe("toObject", function() {
         it("converts parameters to an object", function() {
             var options = new ViewerOptions();
-            options.spreadView(true);
+            options.pageViewMode(PageViewMode.SPREAD);
             options.fontSize(20);
             options.zoom(ZoomOptions.createFromZoomFactor(1.2));
 
             expect(options.toObject()).toEqual({
                 fontSize: 20,
-                spreadView: true,
+                pageViewMode: vivliostyle.viewer.PageViewMode.SPREAD,
                 zoom: 1.2,
                 fitToScreen: false
             });

--- a/test/spec/viewmodels/settings-panel-spec.js
+++ b/test/spec/viewmodels/settings-panel-spec.js
@@ -21,6 +21,7 @@ import ko from "knockout";
 import PageSize from "../../../src/js/models/page-size";
 import DocumentOptions from "../../../src/js/models/document-options";
 import ViewerOptions from "../../../src/js/models/viewer-options";
+import PageViewMode from "../../../src/js/models/page-view-mode";
 import SettingsPanel from "../../../src/js/viewmodels/settings-panel";
 
 describe("SettingsPanel", function() {
@@ -31,14 +32,14 @@ describe("SettingsPanel", function() {
 
     var defaultSettingsPanelOptions = {
         disablePageSizeChange: false,
-        disableSpreadViewChange: false
+        disablePageViewModeChange: false
     };
 
     beforeEach(function() {
         documentOptions = new DocumentOptions();
         documentOptions.pageSize.customWidth("100mm");
         viewerOptions = new ViewerOptions();
-        viewerOptions.spreadView(true);
+        viewerOptions.pageViewMode(PageViewMode.SPREAD);
         viewerOptions.fontSize(10);
         viewer = {loadDocument: function() {}};
         messageDialog = {visible: ko.observable(false)};
@@ -53,7 +54,7 @@ describe("SettingsPanel", function() {
         it("stores the options to 'state' property", function() {
             var settingsPanel = createSettingsPanel();
 
-            expect(settingsPanel.state.viewerOptions.spreadView()).toBe(true);
+            expect(settingsPanel.state.viewerOptions.pageViewMode()).toBe(PageViewMode.SPREAD);
             expect(settingsPanel.state.viewerOptions.fontSize()).toBe(10);
             expect(settingsPanel.state.pageSize.customWidth()).toBe("100mm");
         });
@@ -89,21 +90,21 @@ describe("SettingsPanel", function() {
     describe("apply", function() {
         it("writes parameters from this.state.viewerOptions to the original ViewerOptions if the page size is not changed", function() {
             var settingsPanel = createSettingsPanel();
-            settingsPanel.state.viewerOptions.spreadView(false);
+            settingsPanel.state.viewerOptions.pageViewMode(PageViewMode.SINGLE_PAGE);
             settingsPanel.state.viewerOptions.fontSize(20);
 
-            expect(viewerOptions.spreadView()).toBe(true);
+            expect(viewerOptions.pageViewMode()).toBe(PageViewMode.SPREAD);
             expect(viewerOptions.fontSize()).toBe(10);
 
             settingsPanel.apply();
 
-            expect(viewerOptions.spreadView()).toBe(false);
+            expect(viewerOptions.pageViewMode()).toBe(PageViewMode.SINGLE_PAGE);
             expect(viewerOptions.fontSize()).toBe(20);
         });
 
         it("writes parameters from this.state.pageSize to the original DocumentOptions and call viewer.loadDocument if the page size is changed", function() {
             var settingsPanel = createSettingsPanel();
-            settingsPanel.state.viewerOptions.spreadView(false);
+            settingsPanel.state.viewerOptions.pageViewMode(PageViewMode.SINGLE_PAGE);
             settingsPanel.state.viewerOptions.fontSize(20);
             settingsPanel.state.pageSize.mode(PageSize.Mode.PRESET);
 
@@ -112,7 +113,7 @@ describe("SettingsPanel", function() {
             spyOn(viewer, "loadDocument");
             settingsPanel.apply();
 
-            expect(viewerOptions.spreadView()).toBe(true);
+            expect(viewerOptions.pageViewMode()).toBe(PageViewMode.SPREAD);
             expect(viewerOptions.fontSize()).toBe(10);
             expect(documentOptions.pageSize.mode()).toBe(PageSize.Mode.PRESET);
             expect(viewer.loadDocument).toHaveBeenCalledWith(documentOptions, settingsPanel.state.viewerOptions);
@@ -122,13 +123,13 @@ describe("SettingsPanel", function() {
     describe("reset", function() {
         it("writes parameters from the original ViewerOptions to this.state.viewerOptions", function() {
             var settingsPanel = createSettingsPanel();
-            settingsPanel.state.viewerOptions.spreadView(false);
+            settingsPanel.state.viewerOptions.pageViewMode(PageViewMode.SINGLE_PAGE);
             settingsPanel.state.viewerOptions.fontSize(20);
             settingsPanel.state.pageSize.mode(PageSize.Mode.PRESET);
 
             settingsPanel.reset();
 
-            expect(settingsPanel.state.viewerOptions.spreadView()).toBe(true);
+            expect(settingsPanel.state.viewerOptions.pageViewMode()).toBe(PageViewMode.SPREAD);
             expect(settingsPanel.state.viewerOptions.fontSize()).toBe(10);
             expect(settingsPanel.state.pageSize.mode()).toBe(PageSize.Mode.AUTO);
         });
@@ -140,7 +141,7 @@ describe("SettingsPanel", function() {
 
             expect(settingsPanel.isPageSizeChangeDisabled).toBe(false);
             expect(settingsPanel.isOverrideDocumentStyleSheetDisabled).toBe(false);
-            expect(settingsPanel.isSpreadViewChangeDisabled).toBe(false);
+            expect(settingsPanel.isPageViewModeChangeDisabled).toBe(false);
         });
 
         it("page size change and 'override document style sheet' are disabled by disablePageSizeChange=true in settingsPanelOptions", function() {
@@ -148,15 +149,15 @@ describe("SettingsPanel", function() {
 
             expect(settingsPanel.isPageSizeChangeDisabled).toBe(true);
             expect(settingsPanel.isOverrideDocumentStyleSheetDisabled).toBe(true);
-            expect(settingsPanel.isSpreadViewChangeDisabled).toBe(false);
+            expect(settingsPanel.isPageViewModeChangeDisabled).toBe(false);
         });
 
-        it("spread view change is disabled by disableSpreadViewChangeChange=true in settingsPanelOptions", function() {
-            var settingsPanel = createSettingsPanel({disableSpreadViewChange: true});
+        it("page view mode change is disabled by disablePageViewModeChangeChange=true in settingsPanelOptions", function() {
+            var settingsPanel = createSettingsPanel({disablePageViewModeChange: true});
 
             expect(settingsPanel.isPageSizeChangeDisabled).toBe(false);
             expect(settingsPanel.isOverrideDocumentStyleSheetDisabled).toBe(false);
-            expect(settingsPanel.isSpreadViewChangeDisabled).toBe(true);
+            expect(settingsPanel.isPageViewModeChangeDisabled).toBe(true);
         });
     });
 });


### PR DESCRIPTION
- Page View Mode option is one of the followings: 'Auto' (spread view if the screen is wide enough, single page view otherwise), 'SIngle page' and 'Spread'.
- If the options is not specified by a URL parameter, 'Auto' is chosen by default.