### PR TITLE
Percent-encode and decode '&' and '%' in URL parameter values

### DIFF
--- a/src/js/stores/url-parameters.js
+++ b/src/js/stores/url-parameters.js
@@ -40,13 +40,14 @@ URLParameterStore.prototype.getParameter = function(name) {
     var results = [];
     var r;
     while (r = regexp.exec(url)) {
-        results.push(r[1]);
+        results.push(stringUtil.percentDecodeAmpersandAndPercent(r[1]));
     }
     return results;
 };
 
 URLParameterStore.prototype.setParameter = function(name, value) {
     var url = this.location.href;
+    value = stringUtil.percentEncodeAmpersandAndPercent(value);
     var updated;
     var regexp = getRegExpForParameter(name);
     var r = regexp.exec(url);

--- a/src/js/utils/string-util.js
+++ b/src/js/utils/string-util.js
@@ -23,5 +23,11 @@ export default {
     },
     escapeUnicodeString: function(str) {
         return str.replace(/[^-a-zA-Z0-9_]/g, this.escapeUnicodeChar);
+    },
+    percentEncodeAmpersandAndPercent: function(str) {
+        return str.replace(/%/g, "%25").replace(/&/g, "%26");
+    },
+    percentDecodeAmpersandAndPercent: function(str) {
+        return str.replace(/%26/g, "&").replace(/%25/g, "%");
     }
 };

--- a/test/spec/stores/url-parameters-spec.js
+++ b/test/spec/stores/url-parameters-spec.js
@@ -52,6 +52,11 @@ describe("URLParameterStore", function() {
 
             expect(urlParameters.getParameter("aa")).toEqual(["bb"]);
             expect(urlParameters.getParameter("cc")).toEqual(["dd", "ee"]);
+
+            urlParameters.location = {href: "http://example.com#aa=b#b&cc=dd&cc=ee"};
+
+            expect(urlParameters.getParameter("aa")).toEqual(["b#b"]);
+            expect(urlParameters.getParameter("cc")).toEqual(["dd", "ee"]);
         });
 
         it("can retrieve a value for a unicode key", function() {
@@ -59,6 +64,13 @@ describe("URLParameterStore", function() {
             urlParameters.location = {href: "http://example.com#aa=bb&" + key + "=dd"};
 
             expect(urlParameters.getParameter(key)).toEqual(["dd"]);
+        });
+
+        it("can retrieve values containing '=', percent-encoded '&' and '%'", function() {
+            urlParameters.location = {href: "http://example.com#aa=foo%2525bar%26baz&bb=c=d"};
+
+            expect(urlParameters.getParameter("aa")).toEqual(["foo%25bar&baz"]);
+            expect(urlParameters.getParameter("bb")).toEqual(["c=d"]);
         });
     });
 
@@ -97,6 +109,14 @@ describe("URLParameterStore", function() {
             urlParameters.setParameter("あいうえお", "さしすせそ");
 
             expect(urlParameters.location.href).toBe("http://example.com#あいうえお=さしすせそ");
+        });
+
+        it("can set values containing '=', '&' and '%'", function() {
+            urlParameters.location = {href: "http://example.com#aa=bb"};
+            urlParameters.setParameter("aa", "foo%25bar&baz");
+            urlParameters.setParameter("bb", "c=d");
+
+            expect(urlParameters.location.href).toBe("http://example.com#aa=foo%2525bar%26baz&bb=c=d");
         });
 
         it("use history.replaceState if available", function() {


### PR DESCRIPTION
- Since an '&' character in the URL is treated as a separator for parameters, it was impossible to specify a value containing '&' as a parameter value (e.g. an URL containing query parameters)
- In this commit, the following conversions are added during the parameter retrieval:
  - %25 → %
  - %26 → &
  That is, '%' and '&' should be percent-encoded in URL parameters.

Fixes #48.