### PR TITLE
Do not percent-encode a document fragment twice

### DIFF
--- a/src/js/models/document-options.js
+++ b/src/js/models/document-options.js
@@ -24,7 +24,7 @@ import PageSize from "./page-size";
 function getDocumentOptionsFromURL() {
     var epubUrl = urlParameters.getParameter("b");
     var url = urlParameters.getParameter("x");
-    var fragment = urlParameters.getParameter("f");
+    var fragment = urlParameters.getParameter("f", true);
     var style = urlParameters.getParameter("style");
     var userStyle = urlParameters.getParameter("userStyle");
     return {
@@ -48,7 +48,7 @@ function DocumentOptions() {
     // write fragment back to URL when updated
     this.fragment.subscribe(function(fragment) {
         var encoded = fragment.replace(/[\s+&?=#\u007F-\uFFFF]+/g, encodeURIComponent);
-        urlParameters.setParameter("f", encoded);
+        urlParameters.setParameter("f", encoded, true);
     });
 }
 

--- a/src/js/stores/url-parameters.js
+++ b/src/js/stores/url-parameters.js
@@ -34,20 +34,22 @@ URLParameterStore.prototype.getBaseURL = function() {
     return url.replace(/\/[^/]*$/, "/");
 };
 
-URLParameterStore.prototype.getParameter = function(name) {
+URLParameterStore.prototype.getParameter = function(name, dontPercentDecode) {
     var url = this.location.href;
     var regexp = getRegExpForParameter(name);
     var results = [];
     var r;
     while (r = regexp.exec(url)) {
-        results.push(stringUtil.percentDecodeAmpersandAndPercent(r[1]));
+        var value = r[1];
+        if (!dontPercentDecode) value = stringUtil.percentDecodeAmpersandAndPercent(value);
+        results.push(value);
     }
     return results;
 };
 
-URLParameterStore.prototype.setParameter = function(name, value) {
+URLParameterStore.prototype.setParameter = function(name, value, dontPercentEncode) {
     var url = this.location.href;
-    value = stringUtil.percentEncodeAmpersandAndPercent(value);
+    if (!dontPercentEncode) value = stringUtil.percentEncodeAmpersandAndPercent(value);
     var updated;
     var regexp = getRegExpForParameter(name);
     var r = regexp.exec(url);

--- a/test/spec/models/document-options-spec.js
+++ b/test/spec/models/document-options-spec.js
@@ -36,12 +36,12 @@ describe("DocumentOptions", function() {
 
     describe("constructor", function() {
         it("retrieves parameters from URL", function() {
-            urlParameters.location = {href: "http://example.com#x=abc/def.html&f=ghi&x=jkl/mno.html"};
+            urlParameters.location = {href: "http://example.com#x=abc/def.html&f=ghi%25&x=jkl/mno.html"};
             var options = new DocumentOptions();
 
             expect(options.epubUrl()).toBe("");
             expect(options.url()).toEqual(["abc/def.html", "jkl/mno.html"]);
-            expect(options.fragment()).toBe("ghi");
+            expect(options.fragment()).toBe("ghi%25");
             expect(options.userStyleSheet()).toEqual([]);
 
             urlParameters.location = {href: "http://example.com#b=abc/&f=ghi&style=style1&style=style2&userStyle=style3"};
@@ -58,9 +58,9 @@ describe("DocumentOptions", function() {
     it("write fragment back to URL when updated", function() {
         urlParameters.location = {href: "http://example.com#x=abc/def.html&f=ghi"};
         var options = new DocumentOptions();
-        options.fragment("jkl");
+        options.fragment("jkl%25");
 
-        expect(urlParameters.location.href).toBe("http://example.com#x=abc/def.html&f=jkl");
+        expect(urlParameters.location.href).toBe("http://example.com#x=abc/def.html&f=jkl%25");
     });
 
     describe("toObject", function() {

--- a/test/spec/stores/url-parameters-spec.js
+++ b/test/spec/stores/url-parameters-spec.js
@@ -72,6 +72,12 @@ describe("URLParameterStore", function() {
             expect(urlParameters.getParameter("aa")).toEqual(["foo%25bar&baz"]);
             expect(urlParameters.getParameter("bb")).toEqual(["c=d"]);
         });
+
+        it("does not percent-decode when dontPercentDecode=true", function() {
+            urlParameters.location = {href: "http://example.com#aa=foo%2525bar%26baz"};
+
+            expect(urlParameters.getParameter("aa", true)).toEqual(["foo%2525bar%26baz"]);
+        });
     });
 
     describe("setParameter", function() {
@@ -117,6 +123,13 @@ describe("URLParameterStore", function() {
             urlParameters.setParameter("bb", "c=d");
 
             expect(urlParameters.location.href).toBe("http://example.com#aa=foo%2525bar%26baz&bb=c=d");
+        });
+
+        it("does not percent-encode when dontPercentEncode=true", function() {
+            urlParameters.location = {href: "http://example.com#aa=bb"};
+            urlParameters.setParameter("aa", "foo%25bar", true);
+
+            expect(urlParameters.location.href).toBe("http://example.com#aa=foo%25bar");
         });
 
         it("use history.replaceState if available", function() {


### PR DESCRIPTION
- Since a document fragment is percent-encoded before passed to URLParameterStore, it is not necessary to percent-encode it again on setParameter().
- Added a 'dontPercentEncode' flag to setParameter() and a 'dontPercentDecode' flag to getParameter() to avoid the unnecessary encode and decode.