### PR TITLE
Omit `&f=epubcfi(/2!)` in URL at first page

### DIFF
--- a/src/js/models/document-options.js
+++ b/src/js/models/document-options.js
@@ -48,8 +48,12 @@ class DocumentOptions {
 
         // write fragment back to URL when updated
         this.fragment.subscribe(fragment => {
-            const encoded = fragment.replace(/[\s+&?=#\u007F-\uFFFF]+/g, encodeURIComponent);
-            urlParameters.setParameter("f", encoded, true);
+            if (urlOptions.epubUrl ? fragment == 'epubcfi(/6/2!)' : fragment == 'epubcfi(/2!)') {
+                urlParameters.removeParameter("f");
+            } else {
+                const encoded = fragment.replace(/[\s+&?=#\u007F-\uFFFF]+/g, encodeURIComponent);
+                urlParameters.setParameter("f", encoded, true);
+            }
         });
     }
 

--- a/src/js/stores/url-parameters.js
+++ b/src/js/stores/url-parameters.js
@@ -67,6 +67,26 @@ class URLParameterStore {
             this.location.href = updated;
         }
     }
+
+    removeParameter(name) {
+        const url = this.location.href;
+        let updated;
+        const regexp = getRegExpForParameter(name);
+        const r = regexp.exec(url);
+        if (r) {
+            const end = r.index + r[0].length;
+            if (r[0].charAt(0) == '#') {
+                updated = url.substring(0, r.index + 1) + url.substring(end + 1);
+            } else {
+                updated = url.substring(0, r.index) + url.substring(end);
+            }
+        }
+        if (this.history.replaceState) {
+            this.history.replaceState(null, "", updated);
+        } else {
+            this.location.href = updated;
+        }
+    }
 }
 
 export default new URLParameterStore();


### PR DESCRIPTION
The `&f=epubcfi(…)` fragment was always added in Vivliostyle viewer URL but it's unnecessary when the first page is displayed. So,

- Omit `&f=epubcfi(/2!)` (or `&f=epubcfi(/6/2!)` for EPUB) that represents very beginning of a document.
