### PR TITLE
Add renderAllPages viewer option and improve page number navigation

### DIFF
--- a/src/js/models/viewer-options.js
+++ b/src/js/models/viewer-options.js
@@ -26,7 +26,8 @@ function getViewerOptionsFromURL() {
     const renderAllPages = urlParameters.getParameter("renderAllPages")[0];
     const isEpub = urlParameters.getParameter("b").length && !urlParameters.getParameter("x").length;
     return {
-        renderAllPages: (renderAllPages === "true" ? true : renderAllPages === "false" ? false : !isEpub),
+        // renderAllPages: (renderAllPages === "true" ? true : renderAllPages === "false" ? false : !isEpub),
+        renderAllPages: (renderAllPages === "true" ? true : renderAllPages === "false" ? false : true),
         profile: (urlParameters.getParameter("profile")[0] === "true"),
         pageViewMode: PageViewMode.fromSpreadViewString(urlParameters.getParameter("spread")[0])
     };

--- a/src/js/models/viewer-options.js
+++ b/src/js/models/viewer-options.js
@@ -23,7 +23,10 @@ import PageViewMode from "./page-view-mode";
 import ZoomOptions from "./zoom-options";
 
 function getViewerOptionsFromURL() {
+    const renderAllPages = urlParameters.getParameter("renderAllPages")[0];
+    const isEpub = urlParameters.getParameter("b").length && !urlParameters.getParameter("x").length;
     return {
+        renderAllPages: (renderAllPages === "true" ? true : renderAllPages === "false" ? false : !isEpub),
         profile: (urlParameters.getParameter("profile")[0] === "true"),
         pageViewMode: PageViewMode.fromSpreadViewString(urlParameters.getParameter("spread")[0])
     };
@@ -40,6 +43,7 @@ function getDefaultValues() {
 
 class ViewerOptions {
     constructor(options) {
+        this.renderAllPages = ko.observable();
         this.fontSize = ko.observable();
         this.profile = ko.observable();
         this.pageViewMode = ko.observable();
@@ -49,6 +53,7 @@ class ViewerOptions {
         } else {
             const defaultValues = getDefaultValues();
             const urlOptions = getViewerOptionsFromURL();
+            this.renderAllPages(urlOptions.renderAllPages);
             this.fontSize(defaultValues.fontSize);
             this.profile(urlOptions.profile || defaultValues.profile);
             this.pageViewMode(urlOptions.pageViewMode || defaultValues.pageViewMode);
@@ -62,6 +67,7 @@ class ViewerOptions {
     }
 
     copyFrom(other) {
+        this.renderAllPages(other.renderAllPages());
         this.fontSize(other.fontSize());
         this.profile(other.profile());
         this.pageViewMode(other.pageViewMode());
@@ -70,6 +76,7 @@ class ViewerOptions {
 
     toObject() {
         return {
+            renderAllPages: this.renderAllPages(),
             fontSize: this.fontSize(),
             pageViewMode: this.pageViewMode().toString(),
             zoom: this.zoom().zoom,

--- a/src/js/viewmodels/navigation.js
+++ b/src/js/viewmodels/navigation.js
@@ -46,7 +46,8 @@ class Navigation {
             }
             const spreadContainerElement = this.viewer_.getSpreadContainerElement();
             const firstPageContainer = spreadContainerElement && spreadContainerElement.firstElementChild;
-            return !firstPageContainer || firstPageContainer.style.display != "none";
+            return !firstPageContainer || firstPageContainer.style.display != "none" &&
+                firstPageContainer.getAttribute("data-vivliostyle-first-page") === "true";
         });
 
         this.isNavigateToNextDisabled = ko.pureComputed(() => {
@@ -56,12 +57,14 @@ class Navigation {
             if (this.viewer_.state.status === undefined) {
                 return false;   // needed for test/spec/viewmodels/navigation-spec.js
             }
-            if (this.viewer_.state.status() != vivliostyle.constants.ReadyState.COMPLETE) {
+            if (this.viewerOptions_.renderAllPages() &&
+                this.viewer_.state.status() != vivliostyle.constants.ReadyState.COMPLETE) {
                 return false;
             }
             const spreadContainerElement = this.viewer_.getSpreadContainerElement();
             const lastPageContainer = spreadContainerElement && spreadContainerElement.lastElementChild;
-            return !lastPageContainer || lastPageContainer.style.display != "none";
+            return !lastPageContainer || lastPageContainer.style.display != "none" &&
+                lastPageContainer.getAttribute("data-vivliostyle-last-page") === "true";
         });
 
         this.isNavigateToLeftDisabled = ko.pureComputed(() => {
@@ -101,12 +104,14 @@ class Navigation {
             if (this.viewer_.state.status === undefined) {
                 return false;   // needed for test/spec/viewmodels/navigation-spec.js
             }
-            if (this.viewer_.state.status() != vivliostyle.constants.ReadyState.COMPLETE) {
+            if (this.viewerOptions_.renderAllPages() &&
+                this.viewer_.state.status() != vivliostyle.constants.ReadyState.COMPLETE) {
                 return true;
             }
             const spreadContainerElement = this.viewer_.getSpreadContainerElement();
             const lastPageContainer = spreadContainerElement && spreadContainerElement.lastElementChild;
-            return !lastPageContainer || lastPageContainer.style.display != "none";
+            return !lastPageContainer || lastPageContainer.style.display != "none" &&
+                lastPageContainer.getAttribute("data-vivliostyle-last-page") === "true";
         });
 
         this.hidePageNavigation = !!navigationOptions.disablePageNavigation;

--- a/src/js/viewmodels/viewer.js
+++ b/src/js/viewmodels/viewer.js
@@ -63,10 +63,12 @@ class Viewer {
         this.viewer_.addListener("readystatechange", () => {
             const readyState = this.viewer_.readyState;
             if (intervalID === 0 && readyState === vivliostyle.constants.ReadyState.INTERACTIVE) {
-                intervalID = setInterval(() => {
-                    this.state_.status.value(vivliostyle.constants.ReadyState.LOADING);
-                    this.state_.status.value(vivliostyle.constants.ReadyState.INTERACTIVE);
-                }, 200);
+                if (this.viewerOptions_.renderAllPages()) {
+                    intervalID = setInterval(() => {
+                        this.state_.status.value(vivliostyle.constants.ReadyState.LOADING);
+                        this.state_.status.value(vivliostyle.constants.ReadyState.INTERACTIVE);
+                    }, 200);
+                }
             } else {
                 clearInterval(intervalID);
                 intervalID = 0;
@@ -86,6 +88,7 @@ class Viewer {
             if (cfi) {
                 this.documentOptions_.fragment(cfi);
             }
+            this.afterNavigateToPage();
         });
         this.viewer_.addListener("hyperlink", payload => {
             if (payload.internal) {
@@ -158,42 +161,34 @@ class Viewer {
 
     navigateToPrevious() {
         this.viewer_.navigateToPage("previous");
-        this.afterNavigateToPage();
     }
 
     navigateToNext() {
         this.viewer_.navigateToPage("next");
-        this.afterNavigateToPage();
     }
 
     navigateToLeft() {
         this.viewer_.navigateToPage("left");
-        this.afterNavigateToPage();
     }
 
     navigateToRight() {
         this.viewer_.navigateToPage("right");
-        this.afterNavigateToPage();
     }
 
     navigateToFirst() {
         this.viewer_.navigateToPage("first");
-        this.afterNavigateToPage();
     }
 
     navigateToLast() {
         this.viewer_.navigateToPage("last");
-        this.afterNavigateToPage();
     }
 
     navigateToNthPage(nthPage) {
         this.viewer_.navigateToNthPage(nthPage);
-        this.afterNavigateToPage();
     }
 
     navigateToInternalUrl(href) {
         this.viewer_.navigateToInternalUrl(href);
-        this.afterNavigateToPage();
     }
 
     queryZoomFactor(type) {

--- a/test/spec/models/viewer-options-spec.js
+++ b/test/spec/models/viewer-options-spec.js
@@ -128,7 +128,8 @@ describe("ViewerOptions", function() {
                 fontSize: 20,
                 pageViewMode: vivliostyle.viewer.PageViewMode.SPREAD,
                 zoom: 1.2,
-                fitToScreen: false
+                fitToScreen: false,
+                renderAllPages: true
             });
         });
     });


### PR DESCRIPTION
This viewer option can be specified as URL parameter,

`renderAllPages=true`: Render all pages at the document load time.
`renderAllPages=false`: Render pages when needed to show.

The default mode is `renderAllPages=true`.
considering renderAllPages=false for EPUB (`b=` parameter), but this mode is still experimental
and need further improvement.
