### PR TITLE
Add "Render All Pages" in settings panel, with UI adjustment

### DIFF
--- a/src/html/vivliostyle-viewer.ejs
+++ b/src/html/vivliostyle-viewer.ejs
@@ -25,7 +25,7 @@
 <style id="vivliostyle-page-rules"></style>
 </head>
 <body data-vivliostyle-viewer-status="loading" data-bind="event: {keydown: handleKey}, attr: {'data-vivliostyle-viewer-status': viewer.state.status}">
-<div id="vivliostyle-viewer-viewport" data-vivliostyle-viewer-viewport="true" data-bind="attr: {'data-vivliostyle-page-progression': viewer.state.pageProgression}, click: settingsPanel.close, swipePages: true"></div>
+<div id="vivliostyle-viewer-viewport" data-vivliostyle-viewer-viewport="true" data-bind="attr: {'data-vivliostyle-page-progression': viewer.state.pageProgression}, click: settingsPanel.close, swipePages: true" tabindex="0"></div>
 <span id="vivliostyle-page-navigation-left" title="navigate to left" data-bind="click: navigation.navigateToLeft, css: {'vivliostyle-menu-enabled': !navigation.isNavigateToLeftDisabled()}"></span>
 <span id="vivliostyle-page-navigation-right" title="navigate to right" data-bind="click: navigation.navigateToRight, css: {'vivliostyle-menu-enabled': !navigation.isNavigateToRightDisabled()}"></span>
 <div id="vivliostyle-loading-overlay" data-bind="visible: !isDebug">
@@ -35,7 +35,7 @@
 <!-- MENU BAR -->
 <div id="vivliostyle-menu-bar">
 	<ul class="vivliostyle-menu" id="vivliostyle-menu_misc">
-		<li class="vivliostyle-menu-item" id="vivliostyle-menu-item_misc-toggle" data-bind="css: {'vivliostyle-menu-item_detail-opened': settingsPanel.opened}"><span class="vivliostyle-menu-icon-button" title="Setting" data-bind="menuButton: true, click: settingsPanel.toggle"></span>
+		<li class="vivliostyle-menu-item" id="vivliostyle-menu-item_misc-toggle" data-bind="css: {'vivliostyle-menu-item_detail-opened': settingsPanel.opened}"><span role="button" tabindex="0" class="vivliostyle-menu-icon-button" title="Settings (S)" data-bind="menuButton: true, click: settingsPanel.toggle"></span>
 			<!-- MENU DETAIL -->
 			<div class="vivliostyle-menu-detail">
 				<div class="vivliostyle-menu-detail-main">
@@ -45,7 +45,7 @@
 							<div class="vivliostyle-menu-detail-group-heading"><span>Page View Mode</span></div>
 							<ul class="vivliostyle-menu-detail-group">
 								<li><label><input type="radio" name="vivliostyle-misc_paginate_page-view-mode" value="autoSpread" required data-bind="checked: settingsPanel.state.pageViewMode" /> <span>Auto</span></label></li>
-								<li><label><input type="radio" name="vivliostyle-misc_paginate_page-view-mode" value="singlePage" required data-bind="checked: settingsPanel.state.pageViewMode" /> <span>Single page</span></label></li>
+								<li><label><input type="radio" name="vivliostyle-misc_paginate_page-view-mode" value="singlePage" required data-bind="checked: settingsPanel.state.pageViewMode" /> <span>Single Page</span></label></li>
 								<li><label><input type="radio" name="vivliostyle-misc_paginate_page-view-mode" value="spread" required data-bind="checked: settingsPanel.state.pageViewMode" /> <span>Spread</span></label></li>
 							</ul>
 						</fieldset>
@@ -57,8 +57,8 @@
 									<small>
 										<select name="vivliostyle-misc_paginate_page-size_preset-select" data-bind="foreach: settingsPanel.state.pageSize.PresetSize, value: settingsPanel.state.pageSize.presetSize">
 											<option data-bind="value: $data, text: description"></option>
-										</select>
-										<label><input type="checkbox" name="vivliostyle-misc_paginate_page-size_preset-landscape" data-bind="checked: settingsPanel.state.pageSize.isLandscape" /> - <span>Landscape</span></label>
+										</select>&#x2002;
+										<label><input type="checkbox" name="vivliostyle-misc_paginate_page-size_preset-landscape" data-bind="checked: settingsPanel.state.pageSize.isLandscape" /> <span>Landscape</span></label>
 									</small>
 								</li>
 								<li><label><input type="radio" name="vivliostyle-misc_paginate_page-size" value="custom" required data-bind="checked: settingsPanel.state.pageSize.mode" /> <span>Custom</span></label> -
@@ -71,7 +71,10 @@
 						</fieldset>
 					</div>
 					<div class="vivliostyle-menu-detail-group" data-bind="visible: !settingsPanel.isPageSizeChangeDisabled">
-						<div><label><input type="checkbox" name="vivliostyle-misc_paginate_override-document-stylesheets" data-bind="checked: settingsPanel.state.pageSize.isImportant, disable: settingsPanel.isOverrideDocumentStyleSheetDisabled" /> <span>Override Document StyleSheets</span></label></div>
+						<div><label><input type="checkbox" name="vivliostyle-misc_paginate_override-document-stylesheets" data-bind="checked: settingsPanel.state.pageSize.isImportant, disable: settingsPanel.isOverrideDocumentStyleSheetDisabled" /> <span>Override Document Style Sheets</span></label></div>
+					</div>
+					<div class="vivliostyle-menu-detail-group" data-bind="visible: !settingsPanel.isRenderAllPagesChangeDisabled">
+						<div><label><input type="checkbox" name="vivliostyle-misc_render-all-pages" data-bind="checked: settingsPanel.state.renderAllPages, disable: settingsPanel.isRenderAllPagesChangeDisabled" /> <span>Render All Pages</span> <small>(On: for Print, Off: for Read)</small></label></div>
 					</div>
 					<!--
 					<div class="vivliostyle-menu-detail-group">
@@ -99,8 +102,8 @@
 					</div>
 					-->
 					<div class="vivliostyle-menu-detail-group vivliostyle-menu-detail-group-buttons vivliostyle-menu-detail-group-inline">
-						<div><span class="vivliostyle-menu-button vivliostyle-menu-button-positive" id="vivliostyle-menu-button_apply" data-bind="menuButton: true, click: settingsPanel.apply">Apply</span></div>
-						<div><span class="vivliostyle-menu-button vivliostyle-menu-button-negative" id="vivliostyle-menu-button_reset" data-bind="menuButton: true, click: settingsPanel.reset">Reset</span></div>
+						<div><button type="button" class="vivliostyle-menu-button vivliostyle-menu-button-positive" id="vivliostyle-menu-button_apply" data-bind="menuButton: true, click: settingsPanel.apply">Apply</button></div>
+						<div><button type="button" class="vivliostyle-menu-button vivliostyle-menu-button-negative" id="vivliostyle-menu-button_reset" data-bind="menuButton: true, click: settingsPanel.reset">Cancel</button></div>
 					</div>
 				</div>
 				<div class="vivliostyle-menu-detail-aside">
@@ -115,14 +118,14 @@
 		<li class="vivliostyle-menu-item vivliostyle-menu-disabled" id="vivliostyle-menu-item_move-previous" data-bind="click: navigation.navigateToPrevious, css: {'vivliostyle-menu-disabled': navigation.isNavigateToPreviousDisabled}"><span class="vivliostyle-menu-icon-button" title="Previous Page (↑)" data-bind="menuButton: true"></span></li>
 		<li class="vivliostyle-menu-item vivliostyle-menu-disabled" id="vivliostyle-menu-item_move-next" data-bind="click: navigation.navigateToNext, css: {'vivliostyle-menu-disabled': navigation.isNavigateToNextDisabled}"><span class="vivliostyle-menu-icon-button" title="Next Page (↓)" data-bind="menuButton: true"></span></li>
 		<li class="vivliostyle-menu-item vivliostyle-menu-disabled" id="vivliostyle-menu-item_move-last" data-bind="click: navigation.navigateToLast, css: {'vivliostyle-menu-disabled': navigation.isNavigateToLastDisabled}"><span class="vivliostyle-menu-icon-button" title="Last Page (End)" data-bind="menuButton: true"></span></li>
-		<li class="vivliostyle-menu-item" id="vivliostyle-menu-item_page-number"><input id="vivliostyle-page-number" title="Go to Page… (G)" data-bind="value: navigation.pageNumber" onfocus="setTimeout(()=>{this.setSelectionRange(0,this.value.length)},0)" type="text" inputmode="numeric"/></li>
-		<li class="vivliostyle-menu-item" id="vivliostyle-menu-item_total-pages"><span id="vivliostyle-total-pages" title="Total Pages" data-bind="text: navigation.totalPages"></span></li>
+		<li class="vivliostyle-menu-item" id="vivliostyle-menu-item_page-number" data-bind="css: {'vivliostyle-menu-disabled': navigation.isPageNumberDisabled}"><input id="vivliostyle-page-number" title="Go to Page… (G)" data-bind="value: navigation.pageNumber" onfocus="setTimeout(()=>{this.setSelectionRange(0,this.value.length)},0)" type="text" inputmode="numeric" autocomplete="off"/></li>
+		<li class="vivliostyle-menu-item" id="vivliostyle-menu-item_total-pages"><span id="vivliostyle-total-pages" data-bind="text: navigation.totalPages"></span></li>
 	</ul>
 	<ul class="vivliostyle-menu" id="vivliostyle-menu_zoom" data-bind="visible: !navigation.hideZoom">
-		<li class="vivliostyle-menu-item vivliostyle-menu-disabled" id="vivliostyle-menu-item_zoom-out" data-bind="click: navigation.zoomOut, css: {'vivliostyle-menu-disabled': navigation.isZoomOutDisabled}"><span class="vivliostyle-menu-icon-button" title="Zoom: Out" data-bind="menuButton: true"></span></li>
-		<li class="vivliostyle-menu-item vivliostyle-menu-disabled" id="vivliostyle-menu-item_zoom-in" data-bind="click: navigation.zoomIn, css: {'vivliostyle-menu-disabled': navigation.isZoomInDisabled}"><span class="vivliostyle-menu-icon-button" title="Zoom: In" data-bind="menuButton: true"></span></li>
-		<li class="vivliostyle-menu-item vivliostyle-menu-disabled" id="vivliostyle-menu-item_zoom-to-actual-size" data-bind="click: navigation.zoomToActualSize, css: {'vivliostyle-menu-disabled': navigation.isZoomToActualSizeDisabled}"><span class="vivliostyle-menu-icon-button" title="Zoom: Actual Size" data-bind="menuButton: true"></span></li>
-		<li class="vivliostyle-menu-item vivliostyle-menu-disabled" id="vivliostyle-menu-item_zoom-fit-to-screen" data-bind="click: navigation.toggleFitToScreen, css: {'vivliostyle-menu-disabled': navigation.isToggleFitToScreenDisabled, 'on':navigation.fitToScreen }"><span class="vivliostyle-menu-icon-button" title="Zoom: Fit to screen" data-bind="menuButton: true"></span></li>
+		<li class="vivliostyle-menu-item vivliostyle-menu-disabled" id="vivliostyle-menu-item_zoom-out" data-bind="click: navigation.zoomOut, css: {'vivliostyle-menu-disabled': navigation.isZoomOutDisabled}"><span class="vivliostyle-menu-icon-button" title="Zoom: Out (O)" data-bind="menuButton: true"></span></li>
+		<li class="vivliostyle-menu-item vivliostyle-menu-disabled" id="vivliostyle-menu-item_zoom-in" data-bind="click: navigation.zoomIn, css: {'vivliostyle-menu-disabled': navigation.isZoomInDisabled}"><span class="vivliostyle-menu-icon-button" title="Zoom: In (I)" data-bind="menuButton: true"></span></li>
+		<li class="vivliostyle-menu-item vivliostyle-menu-disabled" id="vivliostyle-menu-item_zoom-to-actual-size" data-bind="click: navigation.zoomToActualSize, css: {'vivliostyle-menu-disabled': navigation.isZoomToActualSizeDisabled}"><span class="vivliostyle-menu-icon-button" title="Zoom: Actual Size (1)" data-bind="menuButton: true"></span></li>
+		<li class="vivliostyle-menu-item vivliostyle-menu-disabled" id="vivliostyle-menu-item_zoom-fit-to-screen" data-bind="click: navigation.toggleFitToScreen, css: {'vivliostyle-menu-disabled': navigation.isToggleFitToScreenDisabled, 'on':navigation.fitToScreen }"><span class="vivliostyle-menu-icon-button" title="Zoom: Fit to Screen (F)" data-bind="menuButton: true"></span></li>
 	</ul>
 	<ul class="vivliostyle-menu" id="vivliostyle-menu_text-size" data-bind="visible: !navigation.hideFontSizeChange">
 		<li class="vivliostyle-menu-item vivliostyle-menu-disabled" id="vivliostyle-menu-item_text-size-smaller" data-bind="click: navigation.decreaseFontSize, css: {'vivliostyle-menu-disabled': navigation.isDecreaseFontSizeDisabled}"><span class="vivliostyle-menu-icon-button" title="Text: Smaller (-)" data-bind="menuButton: true"></span></li>

--- a/src/js/models/document-options.js
+++ b/src/js/models/document-options.js
@@ -28,8 +28,8 @@ function getDocumentOptionsFromURL() {
     const style = urlParameters.getParameter("style");
     const userStyle = urlParameters.getParameter("userStyle");
     return {
-        epubUrl: epubUrl[0] || null,
-        url: url.length ? url : null,
+        epubUrl: epubUrl[0] || null, // epubUrl and url are exclusive
+        url: !epubUrl[0] && url.length ? url : null,
         fragment: fragment[0] || null,
         authorStyleSheet: style.length ? style : [],
         userStyleSheet: userStyle.length ? userStyle : []
@@ -48,7 +48,7 @@ class DocumentOptions {
 
         // write fragment back to URL when updated
         this.fragment.subscribe(fragment => {
-            if (urlOptions.epubUrl ? fragment == 'epubcfi(/6/2!)' : fragment == 'epubcfi(/2!)') {
+            if ((urlOptions.epubUrl ? /^epubcfi\(\/[246]\/2!\)/ : /^epubcfi\(\/2!\)/).test(fragment)) {
                 urlParameters.removeParameter("f");
             } else {
                 const encoded = fragment.replace(/[\s+&?=#\u007F-\uFFFF]+/g, encodeURIComponent);

--- a/src/js/models/page-size.js
+++ b/src/js/models/page-size.js
@@ -46,9 +46,47 @@ class PageSize {
         this.customWidth = ko.observable("210mm");
         this.customHeight = ko.observable("297mm");
         this.isImportant = ko.observable(false);
+        
+        const setDisabledElements = (mode) => {
+            const presetSelectElem = document.getElementsByName("vivliostyle-misc_paginate_page-size_preset-select")[0];
+            if (!presetSelectElem) {
+                return;
+            }
+            const presetLandscapeElem = document.getElementsByName("vivliostyle-misc_paginate_page-size_preset-landscape")[0];
+            const customWidthElem = document.getElementsByName("vivliostyle-misc_paginate_page-size_custom-width")[0];
+            const customHeightElem = document.getElementsByName("vivliostyle-misc_paginate_page-size_custom-height")[0];
+
+            switch (mode) {
+                case Mode.AUTO:
+                    presetSelectElem.disabled = true;
+                    presetLandscapeElem.disabled = true;
+                    customWidthElem.disabled = true;
+                    customHeightElem.disabled = true;
+                    break;
+                case Mode.PRESET:
+                    presetSelectElem.disabled = false;
+                    presetLandscapeElem.disabled = false;
+                    customWidthElem.disabled = true;
+                    customHeightElem.disabled = true;
+                    break;
+                case Mode.CUSTOM:
+                    presetSelectElem.disabled = true;
+                    presetLandscapeElem.disabled = true;
+                    customWidthElem.disabled = false;
+                    customHeightElem.disabled = false;
+                    break;
+            }
+        };
+
         if (pageSize) {
             this.copyFrom(pageSize);
         }
+
+        setDisabledElements(this.mode());
+
+        this.mode.subscribe(mode => {
+            setDisabledElements(mode);
+        });
     }
 
     copyFrom(other) {

--- a/src/js/models/viewer-options.js
+++ b/src/js/models/viewer-options.js
@@ -24,17 +24,17 @@ import ZoomOptions from "./zoom-options";
 
 function getViewerOptionsFromURL() {
     const renderAllPages = urlParameters.getParameter("renderAllPages")[0];
-    const isEpub = urlParameters.getParameter("b").length && !urlParameters.getParameter("x").length;
     return {
-        // renderAllPages: (renderAllPages === "true" ? true : renderAllPages === "false" ? false : !isEpub),
-        renderAllPages: (renderAllPages === "true" ? true : renderAllPages === "false" ? false : true),
+        renderAllPages: (renderAllPages === "true" ? true : renderAllPages === "false" ? false : null),
         profile: (urlParameters.getParameter("profile")[0] === "true"),
         pageViewMode: PageViewMode.fromSpreadViewString(urlParameters.getParameter("spread")[0])
     };
 }
 
 function getDefaultValues() {
+    const isNotEpub = !urlParameters.getParameter("b").length;
     return {
+        renderAllPages: isNotEpub,
         fontSize: 16,
         profile: false,
         pageViewMode: PageViewMode.defaultMode(),
@@ -54,7 +54,8 @@ class ViewerOptions {
         } else {
             const defaultValues = getDefaultValues();
             const urlOptions = getViewerOptionsFromURL();
-            this.renderAllPages(urlOptions.renderAllPages);
+            this.renderAllPages(urlOptions.renderAllPages !== null ?
+                urlOptions.renderAllPages : defaultValues.renderAllPages);
             this.fontSize(defaultValues.fontSize);
             this.profile(urlOptions.profile || defaultValues.profile);
             this.pageViewMode(urlOptions.pageViewMode || defaultValues.pageViewMode);
@@ -62,7 +63,18 @@ class ViewerOptions {
 
             // write spread parameter back to URL when updated
             this.pageViewMode.subscribe(pageViewMode => {
-                urlParameters.setParameter("spread", pageViewMode.toSpreadViewString());
+                if (pageViewMode === defaultValues.pageViewMode) {
+                    urlParameters.removeParameter("spread");
+                } else {
+                    urlParameters.setParameter("spread", pageViewMode.toSpreadViewString());
+                }
+            });
+            this.renderAllPages.subscribe(renderAllPages => {
+                if (renderAllPages === defaultValues.renderAllPages) {
+                    urlParameters.removeParameter("renderAllPages");
+                } else {
+                    urlParameters.setParameter("renderAllPages", renderAllPages.toString());
+                }
             });
         }
     }

--- a/src/js/utils/key-util.js
+++ b/src/js/utils/key-util.js
@@ -28,7 +28,9 @@ const Keys = {
     End: "End",
     PageDown: "PageDown",
     PageUp: "PageUp",
-    Escape: "Escape"
+    Escape: "Escape",
+    Enter: "Enter",
+    Space: " "
 };
 
 // CAUTION: This function covers only part of common keys on a keyboard. Keys not covered by the implementation are identified as KeyboardEvent.key, KeyboardEvent.keyIdentifier, or "Unidentified".
@@ -52,6 +54,10 @@ function identifyKeyFromEvent(event) {
         return Keys.ArrowUp;
     } else if (key === Keys.Escape || key === "Esc" || keyIdentifier === "U+001B") {
         return Keys.Escape;
+    } else if (key === Keys.Enter || keyIdentifier === "Enter") {
+        return Keys.Enter;
+    } else if (key === Keys.Space || keyIdentifier === "U+0020") {
+        return Keys.Space;
     } else if (key === "0" || keyIdentifier === "U+0030") {
         return "0";
     } else if (key === "+" || key === "Add" || keyIdentifier === "U+002B"

--- a/src/js/viewmodels/viewer-app.js
+++ b/src/js/viewmodels/viewer-app.js
@@ -47,7 +47,8 @@ function ViewerApp() {
 
     const settingsPanelOptions = {
         disablePageSizeChange: false,
-        disablePageViewModeChange: false
+        disablePageViewModeChange: false,
+        disableRenderAllPagesChange: false
     };
 
     this.settingsPanel = new SettingsPanel(this.viewerOptions, this.documentOptions, this.viewer, this.messageDialog,
@@ -63,6 +64,9 @@ function ViewerApp() {
 
     this.handleKey = (data, event) => {
         const key = keyUtil.identifyKeyFromEvent(event);
+        if (!(key === "Home" || key === "End") && (event.ctrlKey || event.metaKey) || event.altKey || event.shiftKey) {
+            return true;
+        }
         let ret = this.settingsPanel.handleKey(key);
         if (ret) {
             ret = this.navigation.handleKey(key);

--- a/src/scss/lib/_vars.scss
+++ b/src/scss/lib/_vars.scss
@@ -2,8 +2,8 @@
 // + Vars
 // --------------------------------------------------------------------------------
 
-$sans-serif: "游ゴシック", "Yu Gothic", "YuGothic", "ヒラギノ角ゴ ProN W3", "HiraKakuProN-W3", "ヒラギノ角ゴ Pro W3", "HiraKakuPro-W3", "メイリオ", "Meiryo", "ＭＳ ゴシック", "MS Gothic", sans-serif;
-$serif: "游明朝", "Yu Mincho", "YuMincho", "ヒラギノ明朝 ProN W3", "HiraMinProN-W3", "ヒラギノ明朝 Pro W3", "HiraMinPro-W3", "ＭＳ 明朝", "MS Mincho", sans-serif;
+$sans-serif: Arial, sans-serif;
+$serif: serif;
 
 $menu-icon-offset-x: 2px;
 $menu-icon-offset-y: 2px;

--- a/src/scss/ui.menu-bar.scss
+++ b/src/scss/ui.menu-bar.scss
@@ -167,8 +167,7 @@ $animation-FLIP: FLIP 2s ease 0s infinite normal;
 					height: 1em;
 					line-height: 1;
 					text-align: center;
-					font-family: Verdana;
-					font-size: $menu-icon-height * 0.28;
+					font-size: $menu-icon-height * 0.35;
 					//font-weight: bold;
 				}
 				&.hover  { &:before, &:after { color: black; } background: rgba(255,255,255,0.75); }
@@ -182,6 +181,9 @@ $animation-FLIP: FLIP 2s ease 0s infinite normal;
 			&.vivliostyle-menu-disabled >span {
 				cursor: default;
 				&:before, &:after { color: rgb(128,128,128) !important; } background: transparent !important;
+			}
+			&#vivliostyle-menu-item_page-number.vivliostyle-menu-disabled >#vivliostyle-page-number {
+				background: transparent;
 			}
 		}
 	}
@@ -334,17 +336,19 @@ $animation-FLIP: FLIP 2s ease 0s infinite normal;
 					display: inline-block;
 					position: relative;
 					@include box-sizing(border-box);
-					padding: .6em 1.5em 0;
+					padding: .6em 1.5em;
 					border: solid 1px rgb(128,128,128);
 					border-radius: 1.5em;
 					height: 2.5em;
 					line-height: 1em;
 					font-size: 12px;
 					font-weight: bold;
+					min-width: 7em;
 					cursor: pointer;
 					&.vivliostyle-menu-button-positive {
 						color: black;
 						background: white;
+						box-shadow: 0 0 3px 0 black;
 					}
 					&.vivliostyle-menu-button-negative {
 						color: black;
@@ -368,7 +372,7 @@ $animation-FLIP: FLIP 2s ease 0s infinite normal;
 				}
 				>.vivliostyle-menu-detail-main {
 					overflow-y: auto;
-					height: calc(100% - 2.5em * 12/14);
+					height: calc(100% - 4em * 12/14);
 					font-size: 14px;
 					-webkit-overflow-scrolling: touch;
 					.vivliostyle-menu-detail-group {

--- a/test/spec/models/viewer-options-spec.js
+++ b/test/spec/models/viewer-options-spec.js
@@ -83,9 +83,9 @@ describe("ViewerOptions", function() {
 
         expect(urlParameters.location.href).toBe("http://example.com#spread=true");
 
-        options.pageViewMode(PageViewMode.AUTO_SPREAD);
+        // options.pageViewMode(PageViewMode.AUTO_SPREAD);
 
-        expect(urlParameters.location.href).toBe("http://example.com#spread=auto");
+        // expect(urlParameters.location.href).toBe("http://example.com#spread=auto");
 
         // not write back if it is constructed with another ViewerOptions
         var other = new ViewerOptions();


### PR DESCRIPTION
- Add "Render All Pages" checkbox in the settings panel
- Change default to `RenderAllPages=false` for EPUB (`b=` parameter)
- Omit adding "spread=auto" back to URL, that is default and unnecessary
- Change setting panel "Reset" button to "Cancel" that resets and closes the panel
- Improve keyboard navigation
- Adjust UI style