### PR TITLE
Reflect viewing document title to the web page title

### DIFF
--- a/src/js/stores/url-parameters.js
+++ b/src/js/stores/url-parameters.js
@@ -26,7 +26,8 @@ function getRegExpForParameter(name) {
 class URLParameterStore {
     constructor() {
         this.history = window ? window.history : {};
-        this.location = window ? window.location : {url: ""};
+        this.location = window ? window.location : {href: ""};
+        this.storedUrl = this.location.href;
     }
 
     getBaseURL() {
@@ -66,6 +67,7 @@ class URLParameterStore {
         } else {
             this.location.href = updated;
         }
+        this.storedUrl = updated;
     }
 
     removeParameter(name) {
@@ -86,6 +88,7 @@ class URLParameterStore {
                 this.location.href = updated;
             }
         }
+        this.storedUrl = updated;
     }
 }
 

--- a/src/js/viewmodels/viewer-app.js
+++ b/src/js/viewmodels/viewer-app.js
@@ -77,6 +77,13 @@ function ViewerApp() {
     };
 
     this.viewer.loadDocument(this.documentOptions);
+
+    window.onhashchange = () => {
+        if (window.location.href != urlParameters.storedUrl) {
+            // Reload when address bar change is detected
+            window.location.reload();
+        }
+    };
 }
 
 export default ViewerApp;

--- a/src/js/viewmodels/viewer.js
+++ b/src/js/viewmodels/viewer.js
@@ -80,7 +80,7 @@ class Viewer {
             }
         });
         this.viewer_.addListener("nav", payload => {
-            const {cfi, first, last, epage, epageCount} = payload;
+            const {cfi, first, last, epage, epageCount, metadata, itemTitle} = payload;
             if (cfi) {
                 this.documentOptions_.fragment(cfi);
             }
@@ -95,6 +95,17 @@ class Viewer {
             }
             if (epageCount !== undefined) {
                 this.epageCount(epageCount);
+            }
+            if (metadata || itemTitle) {
+                const bookTitles = metadata && metadata["http://purl.org/dc/terms/title"];
+                const bookTitle = bookTitles && bookTitles[0] && bookTitles[0]["v"];
+                if (!bookTitle) {
+                    document.title = itemTitle;
+                } else if (!itemTitle || itemTitle === bookTitle) {
+                    document.title = bookTitle;
+                } else {
+                    document.title = `${itemTitle} | ${bookTitle}`;
+                }
             }
 
             const tocVisibleOld = this.tocVisible();


### PR DESCRIPTION
- Reflect viewing document title to the web page title.
- Fix problem that the address bar URL fragment change is not honored until manual reload