### PR TITLE
Remove needless mixin for some CSS property

### DIFF
--- a/src/scss/ui.arrows.scss
+++ b/src/scss/ui.arrows.scss
@@ -26,7 +26,7 @@ $button-offset: 0;
     &.vivliostyle-menu-enabled {
         color: rgba(0, 0, 0, 0.25);
         background: rgba(0, 0, 0, 0);
-        @include transition(0.25s ease-out);
+        transition: 0.25s ease-out;
     }
     &:not(.vivliostyle-menu-enabled) {
         display: none;
@@ -34,20 +34,20 @@ $button-offset: 0;
     &[data-vivliostyle-ui-state="attention"] {
         color: rgba(255, 255, 255, 0.75);
         background: rgba(0, 0, 0, 0.125);
-        @include transition(0.25s ease-in);
+        transition: 0.25s ease-in;
     }
     @media (hover: hover), (-moz-touch-enabled: 0) {
         &:hover {
             color: rgba(255, 255, 255, 0.75);
             background: rgba(0, 0, 0, 0.125);
-            @include transition(0.1s linear !important);
+            transition: 0.1s linear !important;
         }
     }
     &.active,
     &:active {
         color: rgba(255, 255, 255, 1);
         background: rgba(0, 0, 0, 0.25);
-        @include transition(0.1s linear !important);
+        transition: 0.1s linear !important;
     }
     &:after {
         box-sizing: content-box;

--- a/src/scss/ui.arrows.scss
+++ b/src/scss/ui.arrows.scss
@@ -50,7 +50,7 @@ $button-offset: 0;
         @include transition(0.1s linear !important);
     }
     &:after {
-        @include box-sizing(content-box);
+        box-sizing: content-box;
         display: block;
         position: absolute;
         left: 0;

--- a/src/scss/ui.loading-overlay.scss
+++ b/src/scss/ui.loading-overlay.scss
@@ -66,7 +66,7 @@ $animation-ROTATE: ROTATE 1.5s linear infinite normal;
     @include on-loading() {
         opacity: 1;
         visibility: visible;
-        @include transition(0.1s liner);
+        transition: 0.1s liner;
         .vivliostyle-loading-spinner {
             @include spinner($spinner-width);
         }
@@ -74,7 +74,7 @@ $animation-ROTATE: ROTATE 1.5s linear infinite normal;
     @include on-interactive() {
         opacity: 0;
         visibility: hidden;
-        @include transition(0.25s ease-out);
+        transition: 0.25s ease-out;
     }
     .vivliostyle-loading-spinner {
         position: absolute;

--- a/src/scss/ui.menu-bar.scss
+++ b/src/scss/ui.menu-bar.scss
@@ -67,7 +67,7 @@ $animation-FLIP: FLIP 2s ease 0s infinite normal;
 // --------------------------------------------------------------------------------
 
 #vivliostyle-menu-bar {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     position: fixed;
     z-index: 88888888;
     left: 0;
@@ -155,7 +155,7 @@ $animation-FLIP: FLIP 2s ease 0s infinite normal;
             > .vivliostyle-menu-icon-button,
             > .vivliostyle-menu-icon-button:before,
             > .vivliostyle-menu-icon-button:after {
-                @include box-sizing(border-box);
+                box-sizing: border-box;
                 display: block;
                 position: absolute;
             }
@@ -455,7 +455,7 @@ $animation-FLIP: FLIP 2s ease 0s infinite normal;
     ul.vivliostyle-menu {
         li.vivliostyle-menu-item {
             .vivliostyle-menu-detail {
-                @include box-sizing(border-box);
+                box-sizing: border-box;
                 display: none;
                 position: fixed;
                 right: 0;
@@ -513,7 +513,7 @@ $animation-FLIP: FLIP 2s ease 0s infinite normal;
                 .vivliostyle-menu-button {
                     display: inline-block;
                     position: relative;
-                    @include box-sizing(border-box);
+                    box-sizing: border-box;
                     padding: 0.6em 1.5em;
                     border: solid 1px rgb(128, 128, 128);
                     border-radius: 1.5em;
@@ -644,7 +644,7 @@ $animation-FLIP: FLIP 2s ease 0s infinite normal;
                     }
                 }
                 > .vivliostyle-menu-detail-aside {
-                    @include box-sizing(border-box);
+                    box-sizing: border-box;
                     position: absolute;
                     left: 0;
                     bottom: 0;

--- a/src/scss/ui.menu-bar.scss
+++ b/src/scss/ui.menu-bar.scss
@@ -170,7 +170,7 @@ $animation-FLIP: FLIP 2s ease 0s infinite normal;
                 &,
                 &:before,
                 &:after {
-                    @include transition(linear 0.1s);
+                    transition: linear 0.1s;
                 }
                 &:before,
                 &:after {
@@ -535,13 +535,13 @@ $animation-FLIP: FLIP 2s ease 0s infinite normal;
                     &.hover {
                         color: white !important;
                         background: black !important;
-                        @include transition(0.1s linear);
+                        transition: 0.1s linear;
                     }
                     &.active {
                         background: rgb(128, 128, 128) !important;
-                        @include transition(0 linear);
+                        transition: 0 linear;
                     }
-                    @include transition(0.15s linear);
+                    transition: 0.15s linear;
                 }
                 small {
                     font-size: 0.9em;
@@ -664,7 +664,7 @@ $animation-FLIP: FLIP 2s ease 0s infinite normal;
                         color: rgb(128, 128, 128);
                         text-decoration: none;
                         border-bottom: solid 1px rgb(192, 192, 192);
-                        @include transition(linear 0.1s);
+                        transition: linear 0.1s;
                         @media (hover: hover), (-moz-touch-enabled: 0) {
                             &:hover {
                                 color: black;


### PR DESCRIPTION
`box-sizing` and `transitions` are do not require vendor prefixes in the each modern browsers.

- https://caniuse.com/#feat=css3-boxsizing
- https://caniuse.com/#feat=css-transitions