### PR TITLE
Fix bug (regression): "Settings→Page Size→Preset" does not work

### DIFF
--- a/src/ts/models/page-style.ts
+++ b/src/ts/models/page-style.ts
@@ -108,6 +108,7 @@ class PageStyle {
   static Mode = Mode;
   static Constants = CONSTANTS;
   static PresetSize = PRESET_SIZE;
+  PresetSize = PageStyle.PresetSize;
 
   constructor(pageStyle?: unknown) {
     this.pageSizeMode = ko.observable(Mode.Default);


### PR DESCRIPTION
This is a regression of #79 (Convert src/js/** to TypeScript)
https://github.com/vivliostyle/vivliostyle-ui/pull/79/commits/98c63f24d79111a170151c02712ba330c6665890

The old JS code "page-style.js" has the assignment `PageStyle.prototype.PresetSize = PresetSize` and this prototype member `PresetSize` is used in https://github.com/vivliostyle/vivliostyle-ui/blob/master/src/html/vivliostyle-viewer.ejs:

```
<select name="vivliostyle-settings_page-size_preset-select" data-bind="foreach: settingsPanel.state.pageStyle.PresetSize, value: settingsPanel.state.pageStyle.presetSize, attr: {tabindex: settingsPanel.state.pageStyle.pageSizeMode()=='preset'?0:-1}">
```

The TS code "page-style.ts" has `static PresetSize = PRESET_SIZE` in PageStyle class, but non static `PresetSize` (equivalent to `PageStyle.prototype.PresetSize`) was missing, and as a result, "Settings→Page Size→Preset" did not work.